### PR TITLE
otel log handler olp

### DIFF
--- a/apps/opentelemetry/src/otel_batch_processor.erl
+++ b/apps/opentelemetry/src/otel_batch_processor.erl
@@ -176,10 +176,7 @@ init([Args=#{reg_name := RegName}]) ->
                      exporter_config=ExporterConfig,
                      resource = Resource,
                      handed_off_table=undefined,
-                     max_queue_size=case SizeLimit of
-                                        infinity -> infinity;
-                                        _ -> SizeLimit div erlang:system_info(wordsize)
-                                    end,
+                     max_queue_size=SizeLimit,
                      exporting_timeout_ms=ExportingTimeout,
                      check_table_size_ms=CheckTableSize,
                      scheduled_delay_ms=ScheduledDelay,

--- a/apps/opentelemetry/src/otel_batch_processor.erl
+++ b/apps/opentelemetry/src/otel_batch_processor.erl
@@ -367,10 +367,15 @@ complete_exporting(Data) ->
                                  handed_off_table=undefined}}.
 
 kill_runner(Data=#data{runner_pid=RunnerPid}) when RunnerPid =/= undefined ->
+    Mon = erlang:monitor(process, RunnerPid),
     erlang:unlink(RunnerPid),
     erlang:exit(RunnerPid, kill),
-    Data#data{runner_pid=undefined,
-              handed_off_table=undefined}.
+    %% Wait for the runner process terminatation to be sure that
+    %% the export table is destroyed and can be safely recreated
+    receive
+        {'DOWN', Mon, process, RunnerPid, _} ->
+            Data#data{runner_pid=undefined, handed_off_table=undefined}
+    end.
 
 new_export_table(Name) ->
      ets:new(Name, [public,

--- a/apps/opentelemetry/src/otel_simple_processor.erl
+++ b/apps/opentelemetry/src/otel_simple_processor.erl
@@ -195,10 +195,15 @@ complete_exporting(Data=#data{current_from=From,
      [{reply, From, ok}]}.
 
 kill_runner(Data=#data{runner_pid=RunnerPid}) when RunnerPid =/= undefined ->
+    Mon = erlang:monitor(process, RunnerPid),
     erlang:unlink(RunnerPid),
     erlang:exit(RunnerPid, kill),
-    Data#data{runner_pid=undefined,
-              handed_off_table=undefined}.
+    %% Wait for the runner process terminatation to be sure that
+    %% the export table is destroyed and can be safely recreated
+    receive
+        {'DOWN', Mon, process, RunnerPid, _} ->
+            Data#data{runner_pid=undefined, handed_off_table=undefined}
+    end.
 
 new_export_table(Name) ->
      ets:new(Name, [public,

--- a/apps/opentelemetry/test/otel_batch_processor_SUITE.erl
+++ b/apps/opentelemetry/test/otel_batch_processor_SUITE.erl
@@ -5,17 +5,19 @@
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("common_test/include/ct.hrl").
 
+-include("otel_span.hrl").
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 
 all() ->
-    [exporting_timeout_test].
+    [exporting_timeout_test,
+     check_table_size_test].
 
 %% verifies that after the runner has to be killed for taking too long
 %% that everything is still functional and the exporter does not crash
 exporting_timeout_test(_Config) ->
     process_flag(trap_exit, true),
 
-    {ok, Pid, _} = otel_batch_processor:start_link(#{reg_name => test_processor,
+    {ok, Pid, _} = otel_batch_processor:start_link(#{name => test_processor,
                                                      resource => otel_resource:create([]),
                                                      exporter => ?MODULE,
                                                      exporting_timeout_ms => 1,
@@ -30,6 +32,34 @@ exporting_timeout_test(_Config) ->
             ok
     end.
 
+check_table_size_test(_Config) ->
+    MaxQueueSize = 10,
+    CheckTableSizeMs = 1,
+    {ok, _Pid, #{reg_name := RegName}} = otel_batch_processor:start_link(
+                                           #{name => test_processor_check_size_test,
+                                             resource => otel_resource:create([]),
+                                             exporter => ?MODULE,
+                                             exporting_timeout_ms => timer:minutes(10),
+                                             %% long enough, so that it never happens during the test
+                                             scheduled_delay_ms => timer:minutes(10),
+                                             check_table_size_ms => CheckTableSizeMs,
+                                             max_queue_size => MaxQueueSize}
+                                          ),
+    %% max_queue_size limit is not reached
+    true = otel_batch_processor:on_end(generate_span(), #{reg_name => RegName}),
+    lists:foreach(fun(_) ->
+                          otel_batch_processor:on_end(generate_span(), #{reg_name => RegName})
+                  end,
+                  lists:seq(1, MaxQueueSize)),
+    %% Wait for more than CheckTablesizeMS to be sure  check timeout occurred
+    timer:sleep(CheckTableSizeMs * 5),
+    dropped = otel_batch_processor:on_end(generate_span(), #{reg_name => RegName}),
+
+    otel_batch_processor:force_flush(#{reg_name => RegName}),
+    %% force_flush is async, have to wait for some long enough time again,
+    timer:sleep(CheckTableSizeMs * 10),
+    true = otel_batch_processor:on_end(generate_span(), #{reg_name => RegName}).
+
 %% exporter behaviour
 
 init(_) ->
@@ -40,3 +70,13 @@ export(_, _) ->
 
 shutdown(_) ->
     ok.
+
+%% helpers
+
+generate_span() ->
+    #span{trace_id = otel_id_generator:generate_trace_id(),
+          span_id = otel_id_generator:generate_span_id(),
+          name = "test_span",
+          trace_flags = 1,
+          is_recording = true,
+          instrumentation_scope = #instrumentation_scope{name = "test"}}.

--- a/apps/opentelemetry_experimental/src/otel_log_handler.erl
+++ b/apps/opentelemetry_experimental/src/otel_log_handler.erl
@@ -1,5 +1,5 @@
 %%%------------------------------------------------------------------------
-%% Copyright 2022, OpenTelemetry Authors
+%% Copyright 2022-2023, OpenTelemetry Authors
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
 %% You may obtain a copy of the License at
@@ -12,7 +12,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%
-%% @doc
+%% @doc Specification: https://opentelemetry.io/docs/specs/otel/logs/sdk
 %% @end
 %%%-------------------------------------------------------------------------
 -module(otel_log_handler).
@@ -20,219 +20,438 @@
 -behaviour(gen_statem).
 
 -include_lib("kernel/include/logger.hrl").
--include_lib("opentelemetry_api/include/opentelemetry.hrl").
 
--export([start_link/2]).
+-export([start_link/1]).
 
+%% Logger handler
 -export([log/2,
          adding_handler/1,
          removing_handler/1,
          changing_config/3,
-         filter_config/1,
          report_cb/1]).
 
+%% gen_statem
 -export([init/1,
          callback_mode/0,
+         init_exporter/3,
          idle/3,
          exporting/3,
-         handle_event/3]).
+         terminate/3]).
+
+%% OpenTelemetry specific
+-export([force_flush/1]).
+
+-export_type([config/0,
+              otel_log_handler_config/0]).
 
 -type config() :: #{id => logger:handler_id(),
-                    regname := atom(),
-                    config => term(),
+                    config => otel_log_handler_config(),
                     level => logger:level() | all | none,
                     module => module(),
                     filter_default => log | stop,
                     filters => [{logger:filter_id(), logger:filter()}],
-                    formatter => {module(), logger:formatter_config()}}.
+                    formatter => {module(), logger:formatter_config()}
+                   }.
 
--define(DEFAULT_CALL_TIMEOUT, 5000).
--define(DEFAULT_MAX_QUEUE_SIZE, 2048).
--define(DEFAULT_SCHEDULED_DELAY_MS, timer:seconds(5)).
--define(DEFAULT_EXPORTER_TIMEOUT_MS, timer:minutes(5)).
+-type config_private() :: #{id => logger:handler_id(),
+                            level => logger:level() | all | none,
+                            module => module(),
+                            filter_default => log | stop,
+                            filters => [{logger:filter_id(), logger:filter()}],
+                            formatter => {module(), logger:formatter_config()},
+                            config := otel_log_handler_config(),
+                            %% private fields
+                            reg_name := atom(),
+                            atomic_ref := atomics:atomic_ref(),
+                            tables := {ets:table(), ets:table()}
+                           }.
+
+-type otel_log_handler_config() ::
+        #{max_queue_size => max_queue_size(),
+          exporting_timeout_ms => exporting_timeout_ms(),
+          scheduled_delay_ms => scheduled_delay_ms(),
+          exporter => exporter_config()}.
+
+-type max_queue_size() :: non_neg_integer() | infinity.
+-type exporter_config() :: module() | {module(), Config :: term()} | undefined.
+-type exporting_timeout_ms() :: non_neg_integer().
+-type scheduled_delay_ms() :: non_neg_integer().
+
+-define(SUP, opentelemetry_experimental_sup).
 
 -define(name_to_reg_name(Module, Id),
         list_to_atom(lists:concat([Module, "_", Id]))).
+-define(table_name(_RegName_, _TabName_), list_to_atom(lists:concat([_RegName_, "_", _TabName_]))).
+-define(table_1(_RegName_), ?table_name(_RegName_, table1)).
+-define(table_2(_RegName_), ?table_name(_RegName_, table2)).
 
--record(data, {exporter             :: {module(), term()} | undefined,
-               exporter_config      :: {module(), term()} | undefined,
-               resource             :: otel_resource:t(),
+%% Use of atomics provides much better overload protection comparing to periodic ETS table size check.
+%% It allows to enter drop mode as soon as max_queue_size is reached, while periodic table check
+%% can overlook a large and fast burst of writes that can result in inserting a much larger amount of
+%% log events than the configured max_queue_size.
+%% Performance-wise, the cost of `atomics:get/2`, `atomics:sub_get/3` is comparable with
+%% `persistent_term:get/2,3`
+-define(current_tab(_AtomicRef_), atomics:get(_AtomicRef_, ?CURRENT_TAB_IX)).
+-define(tab_name(_TabIx_, _Tabs_), element(_TabIx_, _Tabs_)).
+-define(next_tab(_CurrentTab_), case _CurrentTab_ of
+                                    ?TAB_1_IX -> ?TAB_2_IX;
+                                    ?TAB_2_IX -> ?TAB_1_IX
+                                end).
 
-               runner_pid           :: pid() | undefined,
-               max_queue_size       :: integer() | infinity,
-               exporting_timeout_ms :: integer(),
-               scheduled_delay_ms   :: integer(),
+-define(set_current_tab(_AtomicRef_, _TabIx_), atomics:put(_AtomicRef_, ?CURRENT_TAB_IX, _TabIx_)).
+-define(set_available(_AtomicRef_, _TabIx_, _Size_), atomics:put(_AtomicRef_, _TabIx_, _Size_)).
+-define(get_available(_AtomicRef_, _TabIx_), atomics:get(_AtomicRef_, _TabIx_)).
+-define(sub_get_available(_AtomicRef_, _TabIx_), atomics:sub_get(_AtomicRef_, _TabIx_, 1)).
+-define(disable(_AtomicRef_), atomics:put(_AtomicRef_, ?CURRENT_TAB_IX, 0)).
 
-               config :: #{},
-               batch  :: #{opentelemetry:instrumentation_scope() => [logger:log_event()]}}).
+-define(MAX_SIGNED_INT, (1 bsl 63)-1).
+-define(TAB_1_IX, 1).
+-define(TAB_2_IX, 2).
+%% signifies which table is currently enabled (0 - disabled, 1 - table_1, 2 - table_2)
+-define(CURRENT_TAB_IX, 3).
 
-start_link(RegName, Config) ->
-    gen_statem:start_link({local, RegName}, ?MODULE, [RegName, Config], []).
+-define(private_field_err(_FieldName_), {error, {_FieldName_, "private_field_change_not_allowed"}}).
 
--spec adding_handler(Config) -> {ok, Config} | {error, Reason} when
-      Config :: config(),
+-define(DEFAULT_MAX_QUEUE_SIZE, 2048).
+-define(DEFAULT_SCHEDULED_DELAY_MS, timer:seconds(1)).
+-define(DEFAULT_EXPORTER_TIMEOUT_MS, timer:seconds(30)).
+-define(DEFAULT_EXPORTER,
+        {opentelemetry_exporter, #{protocol => grpc, endpoints => ["http://localhost:4317"]}}).
+
+-define(SUP_SHUTDOWN_MS, 5500).
+%% Slightly lower than SUP_SHUTDOWN_MS
+-define(GRACE_SHUTDOWN_MS, 5000).
+-define(time_ms, erlang:monotonic_time(millisecond)).
+-define(rem_time(_Timeout_, _T0_, _T1_), max(0, _Timeout_ - (_T1_ - _T0_))).
+
+-record(data, {exporter              :: {module(), State :: term()} | undefined,
+               exporter_config       :: exporter_config(),
+               resource              :: otel_resource:t(),
+               handed_off_table      :: ets:table() | undefined,
+               runner_pid            :: pid() | undefined,
+               tables                :: {ets:table(), ets:table()},
+               reg_name              :: atom(),
+               config                :: config_private(),
+               max_queue_size        = ?DEFAULT_MAX_QUEUE_SIZE        :: non_neg_integer(),
+               exporting_timeout_ms  = ?DEFAULT_EXPORTER_TIMEOUT_MS   :: exporting_timeout_ms(),
+               scheduled_delay_ms    = ?DEFAULT_SCHEDULED_DELAY_MS    :: scheduled_delay_ms(),
+               atomic_ref            :: atomics:atomic_ref(),
+               exporter_timer        :: undefined | reference(),
+               extra                 = [] %% Unused, for future extensions
+              }).
+
+start_link(#{reg_name := RegName} = Config) ->
+    gen_statem:start_link({local, RegName}, ?MODULE, Config, []).
+
+%% TODO:
+%% - implement max_batch_size (it will also require changes in exporter and/or otel_otlp_logs)
+
+%%--------------------------------------------------------------------
+%% Logger handler callbacks
+%%--------------------------------------------------------------------
+
+-spec adding_handler(Config1) -> {ok, Config2} | {error, Reason} when
+      Config1 :: config(),
+      Config2 :: config_private(),
       Reason :: term().
-adding_handler(#{id := Id,
-                 module := Module}=Config) ->
-    RegName = ?name_to_reg_name(Module, Id),
+adding_handler(#{id := Id}=Config) ->
+    RegName = ?name_to_reg_name(?MODULE, Id),
+    AtomicRef = atomics:new(3, [{signed, true}]),
+    Config1 = Config#{reg_name => RegName,
+                      tables => {?table_1(RegName), ?table_2(RegName)},
+                      atomic_ref => AtomicRef},
+    OtelConfig = maps:get(config, Config, #{}),
+    case validate_config(OtelConfig) of
+        ok ->
+            OtelConfig1 = maps:merge(default_config(), OtelConfig),
+            start(Id, Config1#{config => OtelConfig1});
+        Err ->
+            Err
+    end.
+
+-spec changing_config(SetOrUpdate, OldConfig, NewConfig) ->
+          {ok, Config} | {error, Reason} when
+      SetOrUpdate :: set | update,
+      OldConfig :: config_private(),
+      NewConfig :: config(),
+      Config :: config_private(),
+      Reason :: term().
+changing_config(_, #{reg_name := RegName}, #{reg_name := RegName1}) when RegName =/= RegName1 ->
+    ?private_field_err(reg_name);
+changing_config(_, #{atomic_ref := Ref}, #{atomic_ref := Ref1}) when Ref =/= Ref1 ->
+    ?private_field_err(atomic_ref);
+changing_config(_, #{tables := Tabs}, #{tables := Tabs1}) when Tabs =/= Tabs1 ->
+    ?private_field_err(tables);
+changing_config(_, #{config := #{exporter := Exporter}},
+                #{config := #{exporter := Exporter1}}) when Exporter =/= Exporter1 ->
+    ?private_field_err(exporter);
+changing_config(SetOrUpdate, #{reg_name := RegName, config := OldOtelConfig}, NewConfig) ->
+    NewOtelConfig = maps:get(config, NewConfig, #{}),
+    case validate_config(NewOtelConfig) of
+        ok ->
+            NewOtelConfig1 = case SetOrUpdate of
+                                 update -> maps:merge(OldOtelConfig, NewOtelConfig);
+                                 set -> maps:merge(default_config(), NewOtelConfig)
+                             end,
+            NewConfig1 = NewConfig#{config => NewOtelConfig1, reg_name => RegName},
+            gen_statem:call(RegName, {changing_config, NewConfig1});
+        Err ->
+            Err
+    end.
+
+-spec removing_handler(Config) -> ok | {error, Reason} when
+      Config :: config_private(), Reason :: term().
+removing_handler(_Config=#{id := Id}) ->
+    Res = supervisor:terminate_child(?SUP, Id),
+    _ = supervisor:delete_child(?SUP, Id),
+    Res.
+
+-spec log(LogEvent, Config) -> true | dropped | {error, term()} when
+      LogEvent :: logger:log_event(),
+      Config :: config_private().
+log(LogEvent, Config) ->
+    Ts = case LogEvent of
+                #{meta := #{time := Time}} -> Time;
+                _ -> logger:timestamp()
+            end,
+    do_insert(Ts, LogEvent, Config).
+
+-spec force_flush(config_private()) -> ok.
+force_flush(#{reg_name := RegName}) ->
+    gen_statem:cast(RegName, force_flush).
+
+%%--------------------------------------------------------------------
+%% gen_statem callbacks
+%%--------------------------------------------------------------------
+
+init(Config) ->
+    #{config := OtelConfig,
+      atomic_ref := AtomicRef,
+      reg_name := RegName,
+      tables := {Tab1, Tab2}} = Config,
+    process_flag(trap_exit, true),
+    Resource = otel_resource_detector:get_resource(),
+    ExporterConfig = maps:get(exporter, OtelConfig, ?DEFAULT_EXPORTER),
+    %% assert table names match
+    Tab1 = ?table_1(RegName),
+    Tab2 = ?table_2(RegName),
+    _Tid1 = new_export_table(Tab1),
+    _Tid2 = new_export_table(Tab2),
+
+    Data = #data{atomic_ref=AtomicRef,
+                 exporter=undefined,
+                 exporter_config=ExporterConfig,
+                 resource=Resource,
+                 tables={Tab1, Tab2},
+                 reg_name=RegName,
+                 config = Config},
+    Data1 = add_config_to_data(Config, Data),
+
+    ?set_current_tab(AtomicRef, ?TAB_1_IX),
+    ?set_available(AtomicRef, ?TAB_1_IX, Data1#data.max_queue_size),
+    ?set_available(AtomicRef, ?TAB_2_IX, Data1#data.max_queue_size),
+
+    {ok, init_exporter, Data1}.
+
+callback_mode() ->
+    [state_functions, state_enter].
+
+%% TODO: handle exporter crashes and re-init it.
+%% This is not expected to happen with the default grpc opentelemetry_exporter,
+%% as it keeps running and retrying by itself in case of network failures.
+init_exporter(enter, _OldState, _Data) ->
+    {keep_state_and_data, [{state_timeout, 0, do_init_exporter}]};
+init_exporter(_, do_init_exporter, Data=#data{exporter_config=ExporterConfig,
+                                              atomic_ref=AtomicRef,
+                                              tables=Tabs,
+                                              scheduled_delay_ms=SendInterval}) ->
+    case do_init_exporter(AtomicRef, Tabs, ExporterConfig) of
+        undefined ->
+            {keep_state_and_data, [{state_timeout, SendInterval, do_init_exporter}]};
+        Exporter ->
+            TimerRef = start_exporting_timer(SendInterval),
+            {next_state, idle, Data#data{exporter=Exporter, exporter_timer=TimerRef}}
+    end;
+init_exporter(_, _, _) ->
+    %% Ignore any other, e.g, external events like force_flush in this state
+    keep_state_and_data.
+
+idle(enter, _OldState, _Data) ->
+    keep_state_and_data;
+idle(info, {timeout, Ref, export_logs}, Data=#data{exporter_timer=Ref}) ->
+    {next_state, exporting, Data};
+idle(cast, force_flush, Data) ->
+    {next_state, exporting, Data};
+idle(EventType, EventContent, Data) ->
+    handle_event_(idle, EventType, EventContent, Data).
+
+exporting(info, {timeout, Ref, export_logs}, #data{exporter_timer=Ref}) ->
+    {keep_state_and_data, [postpone]};
+exporting(enter, _OldState, Data=#data{atomic_ref=AtomicRef,
+                                       tables=Tabs,
+                                       max_queue_size=MaxSize,
+                                       exporting_timeout_ms=ExportingTimeout,
+                                       scheduled_delay_ms=SendInterval}) ->
+    CurrentTab = ?current_tab(AtomicRef),
+    {Data1, Actions} =
+        case ?get_available(AtomicRef, CurrentTab) of
+            %% No events yet, maximum available capacity, nothing to export
+            MaxSize ->
+                %% The other table may contain residual (late) writes not exported
+                %% during the previous run. If current table is not empty, we don't
+                %% need to check the size of the previous (currently disabled) table,
+                %% since we will switch to it after this exporter run.
+                %% However, if current table remains empty for a long time,
+                %% neither export nor table switch will be triggered, and any
+                %% residual late log events in the previous table would be left
+                %% dangling. To avoid such cases, we check other table size
+                %% and export it if it's not empty.
+                maybe_export_other_table(CurrentTab, Data);
+            _ ->
+                RunnerPid = export_logs(CurrentTab, Data),
+                {Data#data{runner_pid=RunnerPid,
+                           handed_off_table=?tab_name(CurrentTab, Tabs)},
+                 [{state_timeout, ExportingTimeout, exporting_timeout}]}
+        end,
+    {keep_state, Data1#data{exporter_timer = start_exporting_timer(SendInterval)}, Actions};
+exporting(state_timeout, empty_table, Data) ->
+    {next_state, idle, Data};
+exporting(state_timeout, exporting_timeout, Data) ->
+    %% kill current exporting process because it is taking too long
+    Data1 = kill_runner(Data),
+    {next_state, idle, Data1};
+%% important to verify runner_pid and FromPid are the same in case it was sent
+%% after kill_runner was called but before it had done the unlink
+%% Exit reason is ignored, since we don't handle exporter failures specifically for now
+exporting(info, {'EXIT', FromPid, _}, Data=#data{runner_pid=FromPid}) ->
+    complete_exporting(Data);
+exporting(EventType, Event, Data) ->
+    handle_event_(exporting, EventType, Event, Data).
+
+terminate(_Reason, State, Data=#data{exporter=Exporter,
+                                     resource=Resource,
+                                     config=Config,
+                                     atomic_ref=AtomicRef,
+                                     tables={Tab1, Tab2}
+                                    }) ->
+    ?disable(AtomicRef),
+    T0 = ?time_ms,
+    _ = maybe_wait_for_current_runner(State, Data, ?GRACE_SHUTDOWN_MS),
+    T1 = ?time_ms,
+
+    %% Check both tables as each one may have some late unexported log events.
+    %% NOTE: exports are attempted sequentially to follow the specification restriction:
+    %% "Export will never be called concurrently for the same exporter instance"
+    %% (see: https://opentelemetry.io/docs/specs/otel/logs/sdk/#export).
+    RemTime = ?rem_time(?GRACE_SHUTDOWN_MS, T0, T1),
+    ets:info(Tab1, size) > 0
+        andalso export_and_wait(Exporter, Resource, Tab1, Config, RemTime),
+    T2 = ?time_ms,
+    RemTime1 = ?rem_time(RemTime, T1, T2),
+    ets:info(Tab2, size) > 0
+        andalso export_and_wait(Exporter, Resource, Tab2, Config, RemTime1),
+
+    _ = otel_exporter:shutdown(Exporter),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+start(Id, Config) ->
     ChildSpec =
         #{id       => Id,
-          start    => {?MODULE, start_link, [RegName, Config]},
-          restart  => temporary,
-          shutdown => 2000,
+          start    => {?MODULE, start_link, [Config]},
+          %% The handler must be stopped gracefully by calling `logger:remove_handler/1`,
+          %% which calls `supervisor:terminate_child/2` (in `removing_handler/2` cb).
+          %% Any other termination is abnormal and deserves a restart.
+          restart  => permanent,
+          shutdown => ?SUP_SHUTDOWN_MS,
           type     => worker,
           modules  => [?MODULE]},
-    case supervisor:start_child(opentelemetry_experimental_sup, ChildSpec) of
+    case supervisor:start_child(?SUP, ChildSpec) of
         {ok, _Pid} ->
-            %% ok = logger_handler_watcher:register_handler(Name,Pid),
-            %% OlpOpts = logger_olp:get_opts(Olp),
-            {ok, Config#{regname => RegName}};
+            {ok, Config};
         {error, {Reason, Ch}} when is_tuple(Ch), element(1, Ch) == child ->
             {error, Reason};
         {error, _Reason}=Error ->
             Error
     end.
 
-%%%-----------------------------------------------------------------
-%%% Updating handler config
--spec changing_config(SetOrUpdate, OldConfig, NewConfig) ->
-          {ok,Config} | {error,Reason} when
-      SetOrUpdate :: set | update,
-      OldConfig :: config(),
-      NewConfig :: config(),
-      Config :: config(),
-      Reason :: term().
-changing_config(SetOrUpdate, OldConfig, NewConfig=#{regname := Id}) ->
-    %% eqwalizer:ignore doesn't like gen_`statem:call' returns `term()'
-    gen_statem:call(Id, {changing_config, SetOrUpdate, OldConfig, NewConfig}).
-
-%%%-----------------------------------------------------------------
-%%% Handler being removed
--spec removing_handler(Config) -> ok when
-      Config :: config().
-removing_handler(Config=#{regname := Id}) ->
-    %% eqwalizer:ignore doesn't like gen_`statem:call' returns `term()'
-    gen_statem:call(Id, {removing_handler, Config}).
-
-%%%-----------------------------------------------------------------
-%%% Log a string or report
--spec log(LogEvent, Config) -> ok when
-      LogEvent :: logger:log_event(),
-      Config :: config().
-log(LogEvent, _Config=#{regname := Id}) ->
-    Scope = case LogEvent of
-                #{meta := #{otel_scope := Scope0=#instrumentation_scope{}}} ->
-                    Scope0;
-                #{meta := #{mfa := {Module, _, _}}} ->
-                    opentelemetry:get_application_scope(Module);
-                _ ->
-                    opentelemetry:instrumentation_scope(<<>>, <<>>, <<>>)
-            end,
-
-    gen_statem:cast(Id, {log, Scope, LogEvent}).
-
-%%%-----------------------------------------------------------------
-%%% Remove internal fields from configuration
--spec filter_config(Config) -> Config when
-      Config :: config().
-filter_config(Config=#{regname := Id}) ->
-    %% eqwalizer:ignore doesn't like gen_`statem:call' returns `term()'
-    gen_statem:call(Id, {filter_config, Config}).
-
-init([_RegName, Config]) ->
-    process_flag(trap_exit, true),
-
-    Resource = otel_resource_detector:get_resource(),
-
-    SizeLimit = maps:get(max_queue_size, Config, ?DEFAULT_MAX_QUEUE_SIZE),
-    ExportingTimeout = maps:get(exporting_timeout_ms, Config, ?DEFAULT_EXPORTER_TIMEOUT_MS),
-    ScheduledDelay = maps:get(scheduled_delay_ms, Config, ?DEFAULT_SCHEDULED_DELAY_MS),
-
-    ExporterConfig = maps:get(exporter, Config, {opentelemetry_exporter, #{protocol => grpc}}),
-
-    {ok, idle, #data{exporter=undefined,
-                     exporter_config=ExporterConfig,
-                     resource=Resource,
-                     config=Config,
-                     max_queue_size=case SizeLimit of
-                                        infinity -> infinity;
-                                        _ -> SizeLimit div erlang:system_info(wordsize)
-                                    end,
-                     exporting_timeout_ms=ExportingTimeout,
-                     scheduled_delay_ms=ScheduledDelay,
-                     batch=#{}}}.
-
-callback_mode() ->
-    [state_functions, state_enter].
-
-idle(enter, _OldState, Data=#data{exporter=undefined,
-                                  exporter_config=ExporterConfig,
-                                  scheduled_delay_ms=SendInterval}) ->
-    Exporter = init_exporter(ExporterConfig),
-    {keep_state, Data#data{exporter=Exporter},
-     [{{timeout, export_logs}, SendInterval, export_logs}]};
-idle(enter, _OldState, #data{scheduled_delay_ms=SendInterval}) ->
-    {keep_state_and_data, [{{timeout, export_logs}, SendInterval, export_logs}]};
-idle(_, export_logs, Data=#data{exporter=undefined,
-                                 exporter_config=ExporterConfig}) ->
-    Exporter = init_exporter(ExporterConfig),
-    {next_state, exporting, Data#data{exporter=Exporter}, [{next_event, internal, export}]};
-idle(_, export_logs, Data) ->
-    {next_state, exporting, Data, [{next_event, internal, export}]};
-idle(EventType, EventContent, Data) ->
-    handle_event(EventType, EventContent, Data).
-
-exporting({timeout, export_logs}, export_logs, _) ->
-    {keep_state_and_data, [postpone]};
-exporting(enter, _OldState, _Data) ->
-    keep_state_and_data;
-exporting(internal, export, Data=#data{exporter=Exporter,
-                                       resource=Resource,
-                                       config=Config,
-                                       batch=Batch}) ->
-    map_size(Batch) =:= 0 orelse export(Exporter, Resource, Batch, Config),
-    {next_state, idle, Data#data{batch=#{}}};
-exporting(EventType, EventContent, Data) ->
-    handle_event(EventType, EventContent, Data).
-
-handle_event({call, From}, {changing_config, _SetOrUpdate, _OldConfig, NewConfig}, Data) ->
-    {keep_state, Data#data{config=NewConfig}, [{reply, From, NewConfig}]};
-handle_event({call, From}, {removing_handler, Config}, _Data) ->
-    %% TODO: flush
-    {keep_state_and_data, [{reply, From, Config}]};
-handle_event({call, From}, {filter_handler, Config}, Data) ->
-    {keep_state, Data, [{reply, From, Config}]};
-handle_event({call, From}, {filter_config, Config}, Data) ->
-    {keep_state, Data, [{reply, From, Config}]};
-handle_event({call, _From}, _Msg, _Data) ->
-    keep_state_and_data;
-handle_event(cast, {log, Scope, LogEvent}, Data=#data{batch=Logs}) ->
-    {keep_state, Data#data{batch=maps:update_with(Scope, fun(V) ->
-                                                                  [LogEvent | V]
-                                                          end, [LogEvent], Logs)}};
-handle_event(_, _, _) ->
+handle_event_(_State, {call, From}, {changing_config, NewConfig}, Data) ->
+    {keep_state, add_config_to_data(NewConfig, Data), [{reply, From, {ok, NewConfig}}]};
+handle_event_(_State, info, {'EXIT', Pid, Reason}, #data{runner_pid=RunnerPid})
+  when Pid =/= RunnerPid ->
+    %% This can be a linked exporter process, unless someone linked to the handler process,
+    %% or explicitly called exit(HandlerPid, Reason)
+    %% This will call terminate/3 and may try to export current log events,
+    %% even if the linked exporter process is down.
+    %% This is safe, though, as all errors of otel_exporter:export_logs/4 are caught.
+    {stop, Reason};
+handle_event_(_State, _, _, _) ->
     keep_state_and_data.
 
-%%
-
-init_exporter(ExporterConfig) ->
+do_init_exporter(AtomicRef, Tabs, ExporterConfig) ->
     case otel_exporter:init(ExporterConfig) of
         Exporter when Exporter =/= undefined andalso Exporter =/= none ->
+            %% Need to enable log writes, if it has been disabled previously
+            ?set_current_tab(AtomicRef, ?TAB_1_IX),
             Exporter;
         _ ->
+            %% exporter is undefined/none
+            %% disable the insertion of new log events and delete the current table
+            clear_table_and_disable(AtomicRef, Tabs),
             undefined
     end.
 
+start_exporting_timer(SendInterval) ->
+    erlang:start_timer(SendInterval, self(), export_logs).
+
+maybe_export_other_table(CurrentTab, Data=#data{tables=Tabs,
+                                                exporting_timeout_ms=ExportingTimeout}) ->
+    NextTab = ?next_tab(CurrentTab),
+    %% Check ETS size instead of the counter, as late writes can't be detected with the atomic counter
+    case ets:info(?tab_name(NextTab, Tabs), size) of
+        0 ->
+            %% in an `enter' handler we can't return a `next_state' or `next_event'
+            %% so we rely on a timeout to trigger the transition to `idle'
+            {Data#data{runner_pid=undefined}, [{state_timeout, 0, empty_table}]};
+        _ ->
+            RunnerPid = export_logs(NextTab, Data),
+            {Data#data{runner_pid=RunnerPid, handed_off_table=?tab_name(CurrentTab, Tabs)},
+             [{state_timeout, ExportingTimeout, exporting_timeout}]}
+    end.
+
+export_logs(CurrentTab, #data{exporter=Exporter,
+                              max_queue_size=MaxSize,
+                              resource=Resource,
+                              atomic_ref=AtomicRef,
+                              tables=Tabs,
+                              config=Config}) ->
+
+    NewCurrentTab = ?next_tab(CurrentTab),
+    %% the new table is expected to be empty or hold a few late writes from the previous export,
+    %% so it safe to set available max size
+    ?set_available(AtomicRef, NewCurrentTab, MaxSize),
+    ?set_current_tab(AtomicRef, NewCurrentTab),
+    export_async(Exporter, Resource, ?tab_name(CurrentTab, Tabs), Config).
+
+export_async(Exporter, Resource, CurrentTab, Config) ->
+    erlang:spawn_link(fun() -> export(Exporter, Resource, CurrentTab, Config) end).
+
 export(undefined, _, _, _) ->
     true;
-export({ExporterModule, ExporterConfig}, Resource, Batch, Config) ->
-    %% don't let a exporter exception crash us
-    %% and return true if exporter failed
+export({ExporterModule, ExporterConfig}, Resource, Tab, Config) ->
+    %% TODO: better error handling, `
+    %% failed_not_retryable` is actually never returned from
     try
-        otel_exporter:export_logs(ExporterModule, {Batch, Config}, Resource, ExporterConfig)
+        otel_exporter:export_logs(ExporterModule, {Tab, Config}, Resource, ExporterConfig)
             =:= failed_not_retryable
     catch
         Kind:Reason:StackTrace ->
+            %% Other logger handler(s) (e.g. default) should be enabled, so that
+            %% log events produced by otel_log_handler are not lost in case otel_log_handler
+            %% is not functioning properly.
             ?LOG_WARNING(#{source => exporter,
                            during => export,
                            kind => Kind,
@@ -251,3 +470,141 @@ report_cb(#{source := exporter,
             stacktrace := StackTrace}) ->
     {"log exporter threw exception: exporter=~p ~ts",
      [ExporterModule, otel_utils:format_exception(Kind, Reason, StackTrace)]}.
+
+new_export_table(Name) ->
+    %% log event timestamps used as keys are not guaranteed to always be unique,
+    %% so we use duplicate_bag
+    %% Using timestamps as keys instead of instrumentation scopes is expected
+    %% to have higher entropy which should improve write concurrency
+    ets:new(Name, [public,
+                   named_table,
+                   {write_concurrency, true},
+                   duplicate_bag]).
+
+do_insert(Ts, LogEvent, #{atomic_ref := AtomicRef, tables := Tabs} = Config) ->
+    try
+        case ?current_tab(AtomicRef) of
+            0 -> dropped;
+            CurrentTab ->
+                case ?sub_get_available(AtomicRef, CurrentTab) of
+                    Seq when Seq > 0 ->
+                        ets:insert(?tab_name(CurrentTab, Tabs), {Ts, LogEvent});
+                    0 ->
+                        %% max_queue_size is reached
+                        Res = ets:insert(?tab_name(CurrentTab, Tabs), {Ts, LogEvent}),
+                        _ = force_flush(Config),
+                        Res;
+                    _ ->
+                        dropped
+                end
+        end
+    catch
+        error:badarg ->
+            {error, no_otel_log_handler};
+        Err:Reason ->
+            {error, {Err, Reason}}
+    end.
+
+clear_table_and_disable(AtomicRef, Tabs) ->
+    case ?current_tab(AtomicRef) of
+        0 ->
+            %% already disabled
+            ok;
+        CurrentTab ->
+            ?disable(AtomicRef),
+            CurrentTabName = ?tab_name(CurrentTab, Tabs),
+            ets:delete_all_objects(CurrentTabName),
+            ok
+    end.
+
+complete_exporting(Data) ->
+    {next_state, idle, Data#data{runner_pid=undefined,
+                                 handed_off_table=undefined}}.
+
+kill_runner(Data=#data{runner_pid=RunnerPid, handed_off_table=Tab}) when RunnerPid =/= undefined ->
+    Mon = erlang:monitor(process, RunnerPid),
+    erlang:unlink(RunnerPid),
+    erlang:exit(RunnerPid, kill),
+    %% NOTE: this is not absolutely necessary anymore, as we don't delete/recreate tables
+    receive
+        {'DOWN', Mon, process, RunnerPid, _} ->
+            %% NOTE: if the runner was killed even before it managed to take all or
+            %% at least significant amount of records from the table and
+            %% exporter timeouts keep occurring on and on, there is a risk of continuous
+            %% table size growth. This situation has a low probability,
+            %% especially when the configuration is meaningful, e.g., max_queue_size is not
+            %% enormously large and exporting_timeout is not very small.
+            %% The table is cleared as a safety measure to eliminate the risk of the above case.
+            %% This should probably be optional and configurable.
+            _ = ets:delete_all_objects(Tab),
+            Data#data{runner_pid=undefined, handed_off_table=undefined}
+    end.
+
+
+%% terminate/3 helpers
+
+export_and_wait(Exporter, Resource, Tab, Config, Timeout) ->
+    RunnerPid = export_async(Exporter, Resource, Tab, Config),
+    wait_for_runner(RunnerPid, Timeout).
+
+wait_for_runner(RunnerPid, Timeout) ->
+    receive
+        {'EXIT', RunnerPid, _} -> ok
+    after Timeout ->
+            erlang:exit(RunnerPid, kill),
+            ok
+    end.
+
+maybe_wait_for_current_runner(exporting, #data{runner_pid=RunnerPid}, Timeout) when is_pid(RunnerPid) ->
+    wait_for_runner(RunnerPid, Timeout);
+maybe_wait_for_current_runner(_State, _Date, _Timeout) -> ok.
+
+%% Config helpers
+
+default_config() ->
+    %% exporter is set separately because it's not allowed to be changed for now (requires handler restart)
+    #{max_queue_size => ?DEFAULT_MAX_QUEUE_SIZE,
+      exporting_timeout_ms => ?DEFAULT_EXPORTER_TIMEOUT_MS,
+      scheduled_delay_ms => ?DEFAULT_SCHEDULED_DELAY_MS}.
+
+validate_config(Config) ->
+    Errs = maps:fold(fun(K, Val, Acc) ->
+                             case validate_opt(K, Val, Config) of
+                                 ok -> Acc;
+                                 Err -> [Err | Acc]
+                             end
+              end,
+                     [], Config),
+    case Errs of
+        [] -> ok;
+        _ -> {error, Errs}
+    end.
+
+validate_opt(max_queue_size, infinity, _Config) ->
+    ok;
+validate_opt(K, Val, _Config) when is_integer(Val), Val > 0,
+                          K =:= max_queue_size;
+                          K =:= exporting_timeout_ms;
+                          K =:= scheduled_delay_ms->
+    ok;
+validate_opt(exporter, {Module, _}, _Config) when is_atom(Module) ->
+    ok;
+validate_opt(exporter, Module, _Config) when is_atom(Module) ->
+    ok;
+validate_opt(K, Val, _Config) ->
+    {invalid_config, K, Val}.
+
+add_config_to_data(#{config := OtelConfig} = Config, Data) ->
+    #{max_queue_size:=SizeLimit,
+      exporting_timeout_ms:=ExportingTimeout,
+      scheduled_delay_ms:=ScheduledDelay
+     } = OtelConfig,
+    SizeLimit1 = case SizeLimit of
+                     %% high enough, must be infeasible to reach
+                     infinity -> ?MAX_SIGNED_INT;
+                     Int  -> Int
+                 end,
+    Data#data{config=Config,
+              max_queue_size=SizeLimit1,
+              exporting_timeout_ms=ExportingTimeout,
+              scheduled_delay_ms=ScheduledDelay}.

--- a/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
+++ b/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
@@ -53,7 +53,7 @@ to_proto(Tab, Resource, LogHandlerConfig) ->
     end.
 
 to_proto_by_instrumentation_scope(Tab, LogHandlerConfig) ->
-    %% Even though during the export log eventss are being inserted to another table,
+    %% Even though during the export log events are being inserted to another table,
     %% some late writes to the table being exported are still possible.
     %% Thus, we can't lookup all the log events from the table and then let otel_log_handler
     %% delete the table completely and re-create it as it will imply the risk of losing those (possible) late writes.
@@ -101,8 +101,7 @@ scope(LogEvent, Default) ->
 
 log_record(#{level := Level,
              msg := Body,
-             meta := Metadata=#{time := ObservedTime}}, Config) ->
-    Time = opentelemetry:timestamp(),
+             meta := Metadata=#{time := Time}}, Config) ->
     {SeverityNumber, SeverityText} = level_to_severity(Level),
     Body1 = case format_msg(Body, Metadata, Config) of
                 S when ?IS_STRING(S) ->
@@ -133,8 +132,14 @@ log_record(#{level := Level,
                         #{}
                 end,
 
-    LogRecord#{time_unix_nano          => Time,
-               observed_time_unix_nano => ObservedTime,
+    %% Time produced by logger, the unit is microsecond:
+    %% https://www.erlang.org/doc/man/logger#timestamp-0
+    TimeNano = erlang:convert_time_unit(Time, microsecond, nanosecond),
+
+    LogRecord#{time_unix_nano          => TimeNano,
+               %% Setting the same logger time to both fields, acc. to the specification:
+               %% https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-observedtimestamp
+               observed_time_unix_nano => TimeNano,
                severity_number         => SeverityNumber,
                severity_text           => SeverityText,
                body                    => otel_otlp_common:to_any_value(Body1),

--- a/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
+++ b/apps/opentelemetry_experimental/src/otel_otlp_logs.erl
@@ -31,36 +31,73 @@
 -define(IS_STRING(String),
         (is_list(String) orelse is_binary(String))).
 
-to_proto(Logs, Resource, Config) ->
-    InstrumentationScopeLogs = to_proto_by_instrumentation_scope(Logs, Config),
-    Attributes = otel_resource:attributes(Resource),
-    ResourceLogs = #{resource => #{attributes => otel_otlp_common:to_attributes(Attributes),
-                                   dropped_attributes_count => otel_attributes:dropped(Attributes)},
-                     scope_logs => InstrumentationScopeLogs},
-    case otel_resource:schema_url(Resource) of
-        undefined ->
-            #{resource_logs => [ResourceLogs]};
-        SchemaUrl ->
-            #{resource_logs => [ResourceLogs#{schema_url => SchemaUrl}]}
+-define(DEFAULT_SCOPE, opentelemetry:instrumentation_scope(<<>>, <<>>, <<>>)).
+
+-spec to_proto(ets:table(), otel_resource:t(), logger:handler_config()) ->
+          opentelemetry_exporter_logs_service_pb:export_logs_service_request() | empty.
+to_proto(Tab, Resource, LogHandlerConfig) ->
+    case to_proto_by_instrumentation_scope(Tab, LogHandlerConfig) of
+        [] ->
+            empty;
+        InstrumentationScopeLogs ->
+            Attributes = otel_resource:attributes(Resource),
+            ResourceLogs = #{resource => #{attributes => otel_otlp_common:to_attributes(Attributes),
+                                           dropped_attributes_count => otel_attributes:dropped(Attributes)},
+                             scope_logs => InstrumentationScopeLogs},
+            case otel_resource:schema_url(Resource) of
+                undefined ->
+                    #{resource_logs => [ResourceLogs]};
+                SchemaUrl ->
+                    #{resource_logs => [ResourceLogs#{schema_url => SchemaUrl}]}
+            end
     end.
 
+to_proto_by_instrumentation_scope(Tab, LogHandlerConfig) ->
+    %% Even though during the export log eventss are being inserted to another table,
+    %% some late writes to the table being exported are still possible.
+    %% Thus, we can't lookup all the log events from the table and then let otel_log_handler
+    %% delete the table completely and re-create it as it will imply the risk of losing those (possible) late writes.
+    %% So, we fix the table and traverse it with ets:take/2. After that, the late writes won't be exported,
+    %% but they will be kept in the table and ready to be exported in the next exporter runs.
+    true = ets:safe_fixtable(Tab, true),
+    try
+        to_proto_by_instrumentation_scope(Tab, ets:first(Tab), LogHandlerConfig, #{}, ?DEFAULT_SCOPE)
+    after
+        _ = ets:safe_fixtable(Tab, false)
+    end.
 
-to_proto_by_instrumentation_scope(Logs, Config) ->
-    ScopeLogs = logs_by_scope(Logs, Config),
-    maps:fold(fun(Scope, LogRecords, Acc) ->
-                      [#{scope => otel_otlp_common:to_instrumentation_scope_proto(Scope),
-                         log_records => LogRecords
-                         %% schema_url              => unicode:chardata() % = 3, optional
-                        } | Acc]
-              end, [], ScopeLogs).
+to_proto_by_instrumentation_scope(_Tab, '$end_of_table', _Config, ScopeAcc, _DefaultScope) ->
+    maps:fold(
+      fun(Scope, LogRecords, Acc) ->
+              ScopeProto = otel_otlp_common:to_instrumentation_scope_proto(Scope),
+              [ScopeProto#{log_records => LogRecords} | Acc]
+      end,
+      [],
+      ScopeAcc);
+to_proto_by_instrumentation_scope(Tab, Key, LogHandlerConfig, ScopeAcc, DefaultScope) ->
+    ScopeAcc1 = lists:foldl(
+                  fun({_Ts, LogEvent}, Acc) ->
+                          Scope = scope(LogEvent, DefaultScope),
+                          LogRecord = log_record(LogEvent, LogHandlerConfig),
+                          maps:update_with(Scope,
+                                           fun(Logs) -> [LogRecord | Logs] end,
+                                           [LogRecord],
+                                           Acc)
+                  end,
+                  ScopeAcc,
+                  ets:take(Tab,Key)),
+    Key1 = ets:next(Tab, Key),
+    to_proto_by_instrumentation_scope(Tab, Key1, LogHandlerConfig, ScopeAcc1, DefaultScope).
 
-
-logs_by_scope(ScopeLogs, Config) ->
-    maps:fold(fun(InstrumentationScope, Logs, Acc) ->
-                      LogRecords = [log_record(Log, Config) || Log <- Logs],
-                      Acc#{InstrumentationScope => LogRecords}
-              end, #{}, ScopeLogs).
-
+scope(LogEvent, Default) ->
+    case LogEvent of
+        #{meta := #{otel_scope := Scope0=#instrumentation_scope{}}} ->
+            Scope0;
+        #{meta := #{mfa := {Module, _, _}}} ->
+            opentelemetry:get_application_scope(Module);
+        _ ->
+            Default
+    end.
 
 log_record(#{level := Level,
              msg := Body,
@@ -112,6 +149,7 @@ from_hex_str(Str, Size) ->
 
 format_msg({string, Chardata}, Meta, Config) ->
     format_msg({"~ts", [Chardata]}, Meta, Config);
+%% TODO: check it report_cb is formatter config
 format_msg({report,_}=Msg, Meta, #{report_cb := Fun}=Config)
   when is_function(Fun,1); is_function(Fun,2) ->
     format_msg(Msg, Meta#{report_cb => Fun}, maps:remove(report_cb,Config));

--- a/apps/opentelemetry_experimental/test/otel_log_handler_SUITE.erl
+++ b/apps/opentelemetry_experimental/test/otel_log_handler_SUITE.erl
@@ -1,0 +1,633 @@
+-module(otel_log_handler_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(OTEL_LOG_HANDLER, otel_log_handler).
+-define(LOG_MSG, "otel_log_hanlder_SUITE test, please ignore it").
+-define(TRACEPARENT, "00-0226551413cd73a554184b324c82ad51-b7ad6b71432023a2-01").
+
+all() ->
+    [crud_test,
+     exporting_runner_timeout_test,
+     check_max_queue_test,
+     export_max_queue_size_success_test,
+     scheduled_export_success_test,
+     flush_on_terminate_test,
+     sanity_end_to_end_test,
+     overload_protection_slow_exporter_test,
+     overload_protection_fast_exporter_test,
+     late_writes_test,
+     late_writes_on_terminate_test,
+     no_exporter_test,
+     retry_exporter_init_test,
+     default_opentelemetry_exporter_test,
+     exporter_exit_test].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(exporting_runner_timeout_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    ExporterConf = {?MODULE, #{sleep => infinity}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                scheduled_delay_ms => 10,
+                                exporting_timeout_ms => 1}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC} | Config1];
+init_per_testcase(check_max_queue_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    ExporterConf = {?MODULE, #{sleep => timer:seconds(30)}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => timer:minutes(1),
+                                scheduled_delay_ms => timer:minutes(10),
+                                max_queue_size => 10}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC} | Config1];
+init_per_testcase(export_max_queue_size_success_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    ExporterConf = {?MODULE, #{reply_to => self()}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => 100,
+                                scheduled_delay_ms => timer:minutes(10),
+                                max_queue_size => 10}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC} | Config1];
+init_per_testcase(scheduled_export_success_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    ExporterConf = {?MODULE, #{reply_to => self()}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => 10,
+                                scheduled_delay_ms => 5}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC} | Config1];
+init_per_testcase(flush_on_terminate_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    ExporterConf = {?MODULE, #{reply_to => self()}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => 10,
+                                %% high values to make sure nothing is exported
+                                %% before terminating the handler
+                                scheduled_delay_ms => timer:minutes(10),
+                                max_queue_size => 10000}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC} | Config1];
+init_per_testcase(sanity_end_to_end_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    ExporterConf = {?MODULE, #{otlp => true, reply_to => self()}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => 1000,
+                                %% setting scheduled delay high enough,
+                                %% so that it doesn't occur during the test,
+                                scheduled_delay_ms => timer:minutes(10),
+                                %% the test will produce and expect 5 log events to be exporterd
+                                max_queue_size => 5}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC} | Config1];
+init_per_testcase(overload_protection_slow_exporter_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    ExporterConf = {?MODULE, #{sleep => timer:seconds(10), clean_tab => true}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => timer:seconds(30),
+                                max_queue_size => 500,
+                                scheduled_delay_ms => 5}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC} | Config1];
+init_per_testcase(overload_protection_fast_exporter_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    ExporterConf = {?MODULE, #{clean_tab => true}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => timer:seconds(30),
+                                max_queue_size => 500,
+                                scheduled_delay_ms => 5}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC} | Config1];
+init_per_testcase(late_writes_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    Key = opentelemetry:instrumentation_scope(<<>>, <<>>, <<>>),
+    LateWrites =  [{Key, log_event()} || _ <- lists:seq(1,5)],
+    ExporterConf = {?MODULE, #{reply_to => self(), late_writes => LateWrites}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => timer:seconds(5),
+                                %% high enough, as the test relies on dummy exporter replies order
+                                scheduled_delay_ms => 50}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC}, {late_writes, LateWrites} | Config1];
+init_per_testcase(late_writes_on_terminate_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    Key = opentelemetry:instrumentation_scope(<<>>, <<>>, <<>>),
+    LateWrites =  [{Key, log_event()} || _ <- lists:seq(1,5)],
+    ExporterConf = {?MODULE, #{reply_to => self(), late_writes => LateWrites}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => timer:seconds(5),
+                                %% very high, so that export doesn't happen until termination
+                                scheduled_delay_ms => 50,
+                                %% this must be reached during the test to trigger export
+                                %% and late writes insertion
+                                max_queue_size => 10}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC}, {late_writes, LateWrites} | Config1];
+init_per_testcase(no_exporter_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    ExporterConf = {?MODULE, #{undefined_exporter => true}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => timer:seconds(5),
+                                max_queue_size => 500,
+                                scheduled_delay_ms => 5}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC} | Config1];
+init_per_testcase(retry_exporter_init_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    ExporterConf = {?MODULE, #{retries => 5,
+                               counter => atomics:new(1, []),
+                               reply_to => self()}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => timer:seconds(5),
+                                scheduled_delay_ms => 200}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC} | Config1];
+init_per_testcase(default_opentelemetry_exporter_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    %% no exporter, relying on the default opentelemtry GRPC exporter
+    HandlerConf = #{config => #{exporting_timeout_ms => timer:seconds(5),
+                                scheduled_delay_ms => 10}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC} | Config1];
+init_per_testcase(exporter_exit_test = TC, Config) ->
+    Config1 = common_testcase_init(Config),
+    ExporterSleep = timer:seconds(2),
+    ExporterConf = {?MODULE, #{spawn_link => true, sleep => ExporterSleep, success => true}},
+    HandlerConf = #{config => #{exporter => ExporterConf,
+                                exporting_timeout_ms => timer:seconds(5),
+                                scheduled_delay_ms => 10}},
+    ok = logger:add_handler(TC, ?OTEL_LOG_HANDLER, HandlerConf),
+    [{handler_id, TC}, {exporter_sleep, ExporterSleep} | Config1];
+init_per_testcase(_TC, Config) ->
+    common_testcase_init(Config).
+
+end_per_testcase(_TC, Config) ->
+    case ?config(handler_id, Config) of
+        undefined -> ok;
+        Id -> _ = logger:remove_handler(Id)
+    end,
+    _ = common_testcase_cleanup(Config),
+    ok.
+
+crud_test(_Config) ->
+    ExporterConf = {?MODULE, #{success => true}},
+    HandlerConf = #{config => #{exporter => ExporterConf}},
+    ok = logger:add_handler(otel_handler_test, ?OTEL_LOG_HANDLER, HandlerConf),
+    ok = logger:add_handler(otel_handler_test1, ?OTEL_LOG_HANDLER, HandlerConf),
+    ok = logger:remove_handler(otel_handler_test1),
+    {ok, #{reg_name := RegName}} = logger:get_handler_config(otel_handler_test),
+    true = erlang:is_process_alive(erlang:whereis(RegName)),
+
+    InvalidHandlerConf = #{reg_name => new_reg_name},
+    InvalidHandlerConf1 = #{config => #{exporter => {new_module, #{}}}},
+    InvalidHandlerConf2 = #{atomic_ref => new_atomic_ref},
+    InvalidHandlerConf3 = #{tables => {new_tab1, new_tab2}},
+
+    {error, {reg_name, _}} = logger:set_handler_config(otel_handler_test, InvalidHandlerConf),
+    {error, {exporter, _}} = logger:set_handler_config(otel_handler_test, InvalidHandlerConf1),
+    {error, {reg_name, _}} = logger:update_handler_config(otel_handler_test, InvalidHandlerConf),
+    {error, {exporter, _}} = logger:update_handler_config(otel_handler_test, InvalidHandlerConf1),
+    {error, {exporter, _}} = logger:update_handler_config(otel_handler_test, config,
+                                                          #{exporter => {new_module, #{}}}),
+
+    {error, {atomic_ref, _}} = logger:set_handler_config(otel_handler_test, InvalidHandlerConf2),
+    {error, {tables, _}} = logger:set_handler_config(otel_handler_test, InvalidHandlerConf3),
+    {error, {atomic_ref, _}} = logger:update_handler_config(otel_handler_test, InvalidHandlerConf2),
+    {error, {tables, _}} = logger:update_handler_config(otel_handler_test, InvalidHandlerConf3),
+
+    NewValidConf = #{max_queue_size => infinity,
+                     exporting_timeout_ms => 5000,
+                     scheduled_delay_ms => 3000},
+    ok = logger:update_handler_config(otel_handler_test, #{config => NewValidConf}),
+    ok = logger:update_handler_config(otel_handler_test, config, NewValidConf),
+    ok = logger:set_handler_config(otel_handler_test, #{config => NewValidConf}),
+
+    NewInvalidConf = #{max_queue_size => -100,
+                       exporting_timeout_ms => atom,
+                       scheduled_delay_ms => "string"},
+    {error, [_|_]} = logger:update_handler_config(otel_handler_test, #{config => NewInvalidConf}),
+    {error, [_|_]} = logger:update_handler_config(otel_handler_test, config, NewInvalidConf),
+    {error, [_|_]} = logger:set_handler_config(otel_handler_test, #{config => NewInvalidConf}),
+
+    NewInvalidConf1 = #{unknown_opt => 100},
+    {error, [_|_]} = logger:update_handler_config(otel_handler_test, #{config => NewInvalidConf1}),
+    {error, [_|_]} = logger:update_handler_config(otel_handler_test, config, NewInvalidConf1),
+    {error, [_|_]} = logger:set_handler_config(otel_handler_test, #{config => NewInvalidConf1}),
+
+    ok = logger:remove_handler(otel_handler_test),
+
+    {error, _} = logger:add_handler(otel_handler_test, ?OTEL_LOG_HANDLER, #{config => NewInvalidConf}),
+    {error, _} = logger:add_handler(otel_handler_test, ?OTEL_LOG_HANDLER, #{config => NewInvalidConf1}).
+
+exporting_runner_timeout_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, #{config := #{scheduled_delay_ms := Delay},
+           reg_name := RegName} = HandlerConf} = logger:get_handler_config(HandlerId),
+
+    Mon = erlang:monitor(process, RegName),
+
+    %% Insert a few log events to make sure runner process will be spawned and killed
+    %% because it hangs forever (see `init_per_testcase/2`
+    %% and exporter behaviour defined in this module
+    true = ?OTEL_LOG_HANDLER:log(log_event(), HandlerConf),
+    true = ?OTEL_LOG_HANDLER:log(log_event(), HandlerConf),
+
+    %% Enough time to be sure export is triggered and runner killed
+    Timeout = Delay * 10,
+    receive
+        {'DOWN', Mon, process, _Pid, _} ->
+            %% test is to ensure we don't hit this
+            ct:fail(otel_log_handler_crash)
+    after Timeout ->
+            ok
+    end.
+
+check_max_queue_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, #{config := #{max_queue_size := MaxQueueSize}}
+     = HandlerConf} = logger:get_handler_config(HandlerId),
+
+    true = ?OTEL_LOG_HANDLER:log(log_event(), HandlerConf),
+    true = ?OTEL_LOG_HANDLER:log(log_event(), HandlerConf),
+
+    insert_events(HandlerConf, MaxQueueSize),
+
+    %% Wait a little to give the handler time to transition to the export state
+    timer:sleep(100),
+
+    %% Insert the same number again, rgis time to the next table, as the previous is being exported,
+    %% exporter is slow (see init_per_testcase), so we can be sure that we will go to the drop mode,
+    %% with no chance to switch the table this time.
+    insert_events(HandlerConf, MaxQueueSize),
+
+    dropped = ?OTEL_LOG_HANDLER:log(log_event(), HandlerConf).
+
+export_max_queue_size_success_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, #{config := #{max_queue_size := MaxSize}}
+     = HandlerConf} = logger:get_handler_config(HandlerId),
+
+    erlang:spawn(fun() -> insert_events(HandlerConf, MaxSize) end),
+    %% Export must be triggered by reaching max_export_batch_size because
+    %% scheduled_delay_ms is deliberately set to a high value
+    receive
+        {exported, Size} ->
+            ?assertEqual(MaxSize, Size)
+    after 5000 ->
+            ct:fail(otel_log_handler_exporter_failed)
+    end.
+
+scheduled_export_success_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, HandlerConf} = logger:get_handler_config(HandlerId),
+
+    LogsNum = 10,
+    erlang:spawn(fun() -> insert_events(HandlerConf, LogsNum) end),
+
+    receive
+        {exported, Size} ->
+            ?assertEqual(LogsNum, Size)
+    after 5000 ->
+            ct:fail(otel_log_handler_exporter_failed)
+    end.
+
+flush_on_terminate_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, #{reg_name := RegName} = HandlerConf} = logger:get_handler_config(HandlerId),
+
+    LogsNum = 15,
+    insert_events(HandlerConf, LogsNum),
+
+    ?assert(erlang:is_pid(erlang:whereis(RegName))),
+    ok = logger:remove_handler(HandlerId),
+    receive
+        {exported, Size} ->
+            ?assertEqual(LogsNum, Size)
+    after 5000 ->
+            ct:fail(otel_log_handler_exporter_failed)
+    end,
+    ?assertEqual(undefined, erlang:whereis(RegName)).
+
+sanity_end_to_end_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, #{reg_name := RegName}} = logger:get_handler_config(HandlerId),
+    Mon = erlang:monitor(process, RegName),
+
+    otel_propagator_text_map:extract(otel_propagator_trace_context, [{"traceparent",?TRACEPARENT}]),
+    [_, TraceId, SpanId, _] = string:split(?TRACEPARENT, "-", all),
+    LoggerMeta = logger:get_process_metadata(),
+    ?assertMatch(#{otel_span_id := SpanId, otel_trace_id := TraceId}, LoggerMeta),
+    %% the number of log events must be 5, since init_per_testcase set max_queue_size = 5
+    %% Once 5 events are created, the handler will start exporting, so we can reliably expect 5 items
+    logger:warning(?LOG_MSG),
+    logger:error(?LOG_MSG),
+    logger:warning(#{msg => ?LOG_MSG, foo => [bar, baz]}),
+    logger:error(#{msg => ?LOG_MSG, foo => {bar, [baz]}}),
+    logger:warning(?LOG_MSG ++ "test term: ~p", [#{foo => bar}]),
+    receive
+        {exported, Data} ->
+            #{resource_logs := [#{scope_logs := [#{log_records := LogRecords}]}]} = Data,
+            ?assertEqual(5, length(LogRecords)),
+            {{Y, M, D}, _} = calendar:universal_time(),
+            lists:foreach(
+              fun(#{time_unix_nano := T, observed_time_unix_nano := T,
+                    trace_id := LogTraceId, span_id := LogSpanId}) ->
+                      %% this is to check that timestamps unit is actually nanosecond,
+                      %% as otel_otlp_logs relies on OTP logger producing microsecond timestamps,
+                      %% if it's not nanosecond, calendar:system_time_to_universal_time/2
+                      %% is expected to produce some unrealistic dates
+                      {{LogY, LogM, LogD}, _} = calendar:system_time_to_universal_time(T, nanosecond),
+                      ?assertEqual({Y, M, D}, {LogY, LogM, LogD}),
+                      ?assertEqual(hex_str_to_bin(TraceId, 128), LogTraceId),
+                      ?assertEqual(hex_str_to_bin(SpanId, 64), LogSpanId)
+              end,
+              LogRecords)
+    after 5000 ->
+            ct:fail(otel_log_handler_exporter_failed)
+    end,
+
+    %% No crash is expected during the test
+    receive
+        {'DOWN', Mon, process, _Pid, _} ->
+            %% test is to ensure we don't hit this
+            ct:fail(otel_log_handler_crash)
+    after 100 ->
+            ok
+    end.
+
+overload_protection_slow_exporter_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, #{tables := {Tab1, Tab2},
+           config := #{max_queue_size := MaxSize},
+           reg_name := RegName} = HandlerConf} = logger:get_handler_config(HandlerId),
+
+    Pid1 = spawn(fun() -> insert_loop(HandlerConf) end),
+    Pid2 = spawn(fun() -> insert_loop(HandlerConf) end),
+
+    TimeSec = 20,
+    ct:pal("Running ~p test case for ~p seconds...", [?FUNCTION_NAME, TimeSec]),
+    timer:sleep(timer:seconds(TimeSec)),
+
+    ?assert(ets:info(Tab1, size) =< MaxSize),
+    ?assert(ets:info(Tab2, size) =< MaxSize),
+    ct:pal("otel_log_handler status: ~p", [sys:get_status(RegName)]),
+
+    exit(Pid1, kill),
+    exit(Pid2, kill).
+
+overload_protection_fast_exporter_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, #{tables := {Tab1, Tab2},
+           config := #{max_queue_size := MaxSize},
+           reg_name := RegName} = HandlerConf} = logger:get_handler_config(HandlerId),
+
+    Pid1 = spawn(fun() -> insert_loop(HandlerConf) end),
+    Pid2 = spawn(fun() -> insert_loop(HandlerConf) end),
+
+    TimeSec = 20,
+    ct:pal("Running ~p test case for ~p seconds...", [?FUNCTION_NAME, TimeSec]),
+    timer:sleep(timer:seconds(TimeSec)),
+
+    %% TODO: it probably can be flaky under some race conditions
+    ?assert(ets:info(Tab1, size) =< MaxSize),
+    ?assert(ets:info(Tab2, size) =< MaxSize),
+    ct:pal("otel_log_handler status: ~p", [sys:get_status(RegName)]),
+
+    exit(Pid1, kill),
+    exit(Pid2, kill).
+
+
+%% this test mimics late inserts, that must be exported during the next exporter run
+late_writes_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, HandlerConf} = logger:get_handler_config(HandlerId),
+    LateWritesSize = length(?config(late_writes, Config)),
+    NormalEventsSize = 7,
+    insert_events(HandlerConf, NormalEventsSize),
+
+    receive
+        {exported, Size} ->
+            ?assertEqual(NormalEventsSize, Size),
+            %% There is no strict ordering guarantee, as exported replies are sent by
+            %% different runner processes. The test relies on the fact that there is
+            %% a delay between two exporter runs.
+            receive
+                {exported, Size1} ->
+                    ?assertEqual(LateWritesSize, Size1)
+            after 5000 ->
+                    ct:fail(otel_log_handler_late_writes_exporter_failed)
+            end
+    after 5000 ->
+            ct:fail(otel_log_handler_exporter_failed)
+    end.
+
+%% similar to late_writes_test but checks that the other table is checked and exported on termination
+late_writes_on_terminate_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, #{config := #{max_queue_size := MaxSize}}
+     = HandlerConf} = logger:get_handler_config(HandlerId),
+    LateWritesSize = length(?config(late_writes, Config)),
+    insert_events(HandlerConf, MaxSize),
+
+    receive
+        {exported, Size} ->
+            ?assertEqual(MaxSize, Size)
+    after 5000 ->
+            ct:fail(otel_log_handler_exporter_failed)
+    end,
+
+    ok = logger:remove_handler(HandlerId),
+    receive
+        {exported, Size1} ->
+            ?assertEqual(LateWritesSize, Size1)
+    after 5000 ->
+            ct:fail(otel_log_handler_late_writes_exporter_failed)
+    end.
+
+no_exporter_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, #{config := #{scheduled_delay_ms := Delay},
+           reg_name := RegName} = HandlerConf} = logger:get_handler_config(HandlerId),
+    Mon = erlang:monitor(process, RegName),
+
+    %% Enough time to be sure export is triggered and state transition happened
+    Timeout = Delay * 10,
+    receive
+        {'DOWN', Mon, process, _Pid, _} ->
+            %% test is to ensure we don't hit this
+            ct:fail(otel_log_handler_crash)
+    after Timeout ->
+            ok
+    end,
+    %% Must be disabled
+    ?assertEqual(dropped, ?OTEL_LOG_HANDLER:log(log_event(), HandlerConf)).
+
+retry_exporter_init_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, HandlerConf} = logger:get_handler_config(HandlerId),
+    receive
+        exporter_not_ready ->
+            %% wait a little to give the handler time to disable
+            timer:sleep(50),
+            ?assertEqual(dropped, ?OTEL_LOG_HANDLER:log(log_event(), HandlerConf)),
+            receive
+                exporter_ready ->
+                    %% give some time to the handler to enable
+                    timer:sleep(50),
+                    ?assertEqual(true, ?OTEL_LOG_HANDLER:log(log_event(), HandlerConf))
+            after
+                %% higher timeout, as we need to wait for several exporter init retries
+                5000 ->
+                    ct:fail(otel_log_handler_exporter_init_failed)
+            end
+    after 2000 ->
+            ct:fail(otel_log_handler_exporter_failed)
+    end.
+
+%% opentelmetry_exporter is expected to successfully initialize and keep running
+%% in disconected state (even though there is no collector to connect to).
+%%  This test only checks that no crashes occur
+default_opentelemetry_exporter_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    {ok, #{config := #{scheduled_delay_ms := Delay},
+           reg_name := RegName} = HandlerConf} = logger:get_handler_config(HandlerId),
+    Mon = erlang:monitor(process, RegName),
+
+    insert_events(HandlerConf, 10),
+    %% Give it some time to run and do state transition
+    Timeout = Delay * 10,
+    receive
+        {'DOWN', Mon, process, _Pid, _} ->
+            %% test is to ensure we don't hit this
+            ct:fail(otel_log_handler_crash)
+    after Timeout ->
+            ok
+    end.
+
+exporter_exit_test(Config) ->
+    HandlerId = ?config(handler_id, Config),
+    ExporterSleep = ?config(exporter_sleep, Config),
+    {ok, #{reg_name := RegName}} = logger:get_handler_config(HandlerId),
+    Mon = erlang:monitor(process, RegName),
+
+    Timeout = ExporterSleep * 2,
+    receive
+        {'DOWN', Mon, process, _Pid, test_exporter_crash} ->
+            %% supervisor must restart the handler
+            ?assert(wait_for_restart(RegName, 1000))
+    after Timeout ->
+            ct:fail(otel_log_handler_no_exit)
+    end.
+
+%% exporter behaviour
+init(#{undefined_exporter := true}) ->
+    ignore;
+init(#{retries := N, counter := Ref, reply_to := Pid} = ExpConfig) ->
+    case atomics:add_get(Ref, 1, 1) of
+        N ->
+            Pid ! exporter_ready,
+            {ok, ExpConfig};
+        _ ->
+            Pid ! exporter_not_ready,
+            ignore
+    end;
+init(#{spawn_link := true, sleep := Time} = ExpConfig) ->
+    F = fun () -> timer:sleep(Time),
+                  exit(test_exporter_crash)
+        end,
+    Pid = erlang:spawn_link(F),
+    {ok, ExpConfig#{exporter_pid => Pid}};
+init(ExpConfig) ->
+    {ok, ExpConfig}.
+
+export(logs, {Tab, _LogHandlerConfig}, _Resource, #{sleep := Time} = State) ->
+    timer:sleep(Time),
+    case State of
+        %% Mimic an exporter that must take records from the table
+        %% (even if export failed, taken records are not inserted back to the table)
+        #{clean_tab := true} ->
+            {ok, _Size} = traverse_clean(Tab),
+            ok;
+        _ -> ok
+    end,
+    ok;
+export(logs, {_Tab, _LogHandlerConfig}, _Resource, #{success := true} =_State) ->
+    ok;
+export(logs, {Tab, LogHandlerConfig}, Resource, #{otlp := true, reply_to := Pid} = _State) ->
+    Res = otel_otlp_logs:to_proto(Tab, Resource, LogHandlerConfig),
+    Pid ! {exported, Res};
+export(logs, {Tab, _LogHandlerConfig}, _Resource, #{reply_to := Pid} = State) ->
+    {ok, Size} = traverse_clean(Tab),
+    Pid ! {exported, Size},
+    case State of
+        #{late_writes := Records} ->
+            ets:insert(Tab, Records);
+        _ -> ok
+    end,
+    ok;
+export(logs, {Tab, _LogHandlerConfig}, _Resource, #{clean_tab := true} = _State) ->
+    {ok, _Size} = traverse_clean(Tab),
+    ok.
+
+shutdown(_) ->
+    ok.
+
+%% helpers
+
+common_testcase_init(Config) ->
+    {ok, _} = application:ensure_all_started(opentelemetry_exporter),
+    {ok, _} = application:ensure_all_started(opentelemetry_experimental),
+    Config.
+
+common_testcase_cleanup(_Config) ->
+    _ = application:stop(opentelemetry_experimental),
+    _ = application:stop(opentelemetry_exporter),
+    ok.
+
+log_event() ->
+    #{level => warning,
+      meta => #{gl => erlang:group_leader(), pid => erlang:self(), time => os:system_time(microsecond)},
+      msg => {string, ?LOG_MSG}}.
+
+hex_str_to_bin(Str, Size) ->
+    B = iolist_to_binary(Str),
+    <<(binary_to_integer(B, 16)):Size>>.
+
+insert_events(HandlerConf, N) ->
+    lists:foreach(fun(_) -> ?OTEL_LOG_HANDLER:log(log_event(), HandlerConf) end,
+                  lists:seq(1, N)).
+
+insert_loop(HandlerConf) ->
+    ?OTEL_LOG_HANDLER:log(log_event(), HandlerConf),
+    insert_loop(HandlerConf).
+
+traverse_clean(Tab) ->
+    try
+        ets:safe_fixtable(Tab, true),
+        traverse_clean(Tab, ets:first(Tab), 0)
+    after
+        ets:safe_fixtable(Tab, false)
+    end.
+
+traverse_clean(Tab, '$end_of_table', Seq) ->
+    ct:pal("Exported: ~p records from table: ~p", [Seq, Tab]),
+    {ok, Seq};
+traverse_clean(Tab, Key, Seq) ->
+    %% Tab type is duplicate_bag, keys can be non unique
+    Records = ets:take(Tab, Key),
+    traverse_clean(Tab, ets:next(Tab, Key), Seq+length(Records)).
+
+wait_for_restart(_, 0) -> false;
+wait_for_restart(RegName, Retries) ->
+    timer:sleep(1),
+    is_pid(whereis(RegName)) orelse wait_for_restart(RegName, Retries-1).


### PR DESCRIPTION
The implementation mostly copies https://github.com/emqx/opentelemetry-erlang/blob/main/apps/opentelemetry/src/otel_batch_processor.erl, but there are already some fixes/improvements that I'm going to apply to batch processor afterwards as well. 

The main idea: 
 - Log events are being written to ETS table
 - the handler is a gen state machine that periodically checks the table, traverses it and runs the exporter
 - the handler also switches between two tables (via persistent_term), so that logs are being written to one table while the other is being exported. Notice, however, that late writes to the table being exported are still possible (no way to guarantee all current writers have completed after we switched the table name in the persistent term). This is not a problem, though (there are some comments in the code explaining this case)
 - overload protection is achieved by checking ETS table size and disabling logging via persistent term following OpenTelemetry specification. 
 
 The implementation is generally compatible with OpenTelemetry specification: https://opentelemetry.io/docs/specs/otel/logs/sdk,
 with a few features missing for now (force_flush, hard ` max_export_batch_size` limit for items being exported). 
 Exporter need some refinements (error handling) , but it's planned to be implemented in a separate PR
