### PR TITLE
Refactor otel batch procesor

### DIFF
--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -54,6 +54,8 @@ start(_StartType, _StartArgs) ->
     end.
 
 stop(_State) ->
+    _ = opentelemetry:cleanup_persistent_terms(),
+    _ = otel_span_limits:cleanup_persistent_terms(),
     ok.
 
 %% internal functions

--- a/apps/opentelemetry/src/otel_batch_olp.erl
+++ b/apps/opentelemetry/src/otel_batch_olp.erl
@@ -1,0 +1,605 @@
+%%%------------------------------------------------------------------------
+%% Copyright 2023, OpenTelemetry Authors
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc Common overload protection implementation
+%% @end
+%%%-------------------------------------------------------------------------
+
+-module(otel_batch_olp).
+
+-behaviour(gen_statem).
+
+-export([init_conf/1,
+         start_link/2,
+         insert_signal/2,
+         change_config/3,
+         force_flush/1]).
+
+%% gen_statem
+-export([init/1,
+         callback_mode/0,
+         init_exporter/3,
+         idle/3,
+         exporting/3,
+         terminate/3]).
+
+-export_type([otel_batch_olp_config/0,
+              otel_batch_olp_state/0,
+              max_queue_size/0,
+              otel_timeout_ms/0]).
+
+-include_lib("kernel/include/logger.hrl").
+
+%% Metrics are implmented separately
+-type otel_signal() :: traces | logs.
+
+-type otel_batch_olp_config() ::
+        #{reg_name := atom(),
+          cb_module := module(),
+          otel_signal := otel_signal(),
+          max_queue_size := max_queue_size(),
+          exporting_timeout_ms := pos_integer(),
+          scheduled_delay_ms := pos_integer(),
+          exporter := otel_exporter:exporter_config(),
+          shutdown_timeout_ms => pos_integer(),
+          extra_ets_opts => [{keypos, pos_integer()}],
+          resource => otel_resource:t()
+      }.
+
+%% External state returned to the caller, necessary to be able to communicate with
+%% otel_batch_olp either via calls or inserts to ETS tables.
+-type otel_batch_olp_state() ::
+        #{reg_name := atom(),
+          cb_module := module(),
+          otel_signal := otel_signal(),
+          tables := {ets:table(), ets:table()},
+          atomic_ref := atomics:atomic_ref(),
+          extra_ets_opts => [{keypos, pos_integer()}],
+          max_queue_size => max_queue_size(),
+          exporting_timeout_ms => otel_timeout_ms(),
+          scheduled_delay_ms => otel_timeout_ms(),
+          shutdown_timeout_ms => otel_timeout_ms(),
+          exporter => otel_exporter:exporter_config()
+        }.
+
+-type max_queue_size() :: pos_integer() | infinity.
+-type otel_timeout_ms() :: pos_integer().
+
+-define(table_name(_RegName_, _TabName_), list_to_atom(lists:concat([_RegName_, "_", _TabName_]))).
+-define(table_1(_RegName_), ?table_name(_RegName_, table1)).
+-define(table_2(_RegName_), ?table_name(_RegName_, table2)).
+
+%% Use of atomics provides much better overload protection comparing to periodic ETS table size check.
+%% It allows to enter drop mode as soon as max_queue_size is reached, while periodic table check
+%% can overlook a large and fast burst of writes that can result in inserting a much larger amount of
+%% log events than the configured max_queue_size.
+%% Performance-wise, the cost of `atomics:get/2`, `atomics:sub_get/3` is comparable with
+%% `persistent_term:get/2,3`
+-define(current_tab(_AtomicRef_), atomics:get(_AtomicRef_, ?CURRENT_TAB_IX)).
+-define(tab_name(_TabIx_, _Tabs_), element(_TabIx_, _Tabs_)).
+-define(next_tab(_CurrentTab_), case _CurrentTab_ of
+                                    ?TAB_1_IX -> ?TAB_2_IX;
+                                    ?TAB_2_IX -> ?TAB_1_IX
+                                end).
+
+-define(set_current_tab(_AtomicRef_, _TabIx_), atomics:put(_AtomicRef_, ?CURRENT_TAB_IX, _TabIx_)).
+-define(set_available(_AtomicRef_, _TabIx_, _Size_), atomics:put(_AtomicRef_, _TabIx_, _Size_)).
+-define(get_available(_AtomicRef_, _TabIx_), atomics:get(_AtomicRef_, _TabIx_)).
+-define(sub_get_available(_AtomicRef_, _TabIx_), atomics:sub_get(_AtomicRef_, _TabIx_, 1)).
+-define(disable(_AtomicRef_), atomics:put(_AtomicRef_, ?CURRENT_TAB_IX, 0)).
+
+-define(MAX_SIGNED_INT, (1 bsl 63)-1).
+-define(TAB_1_IX, 1).
+-define(TAB_2_IX, 2).
+%% signifies which table is currently enabled (0 - disabled, 1 - table_1, 2 - table_2)
+-define(CURRENT_TAB_IX, 3).
+
+-define(DEFAULT_SHUTDOWN_MS, 5000).
+-define(DEFAULT_EXPORTER_MODULE, opentelemetry_exporter).
+
+-define(time_ms, erlang:monotonic_time(millisecond)).
+-define(rem_time(_Timeout_, _T0_, _T1_), max(0, _Timeout_ - (_T1_ - _T0_))).
+
+-define(private_field_err(_FieldName_), {error, {_FieldName_, "private_field_change_not_allowed"}}).
+-define(change_not_allowed_err(_FieldName_), {error, {_FieldName_, "field_change_not_allowed"}}).
+
+-record(data, {exporter              :: {module(), State :: term()} | ignore | undefined,
+               exporter_config       :: otel_exporter:exporter_config(),
+               resource              :: otel_resource:t(),
+               handed_off_table      :: ets:table() | undefined,
+               runner                :: {pid(), reference()} | undefined,
+               tables                :: {ets:table(), ets:table()},
+               reg_name              :: atom(),
+               max_queue_size        :: max_queue_size(),
+               exporting_timeout_ms  :: otel_timeout_ms(),
+               scheduled_delay_ms    :: otel_timeout_ms(),
+               shutdown_ms           :: otel_timeout_ms(),
+               atomic_ref            :: atomics:atomic_ref(),
+               exporter_timer        :: undefined | reference(),
+               otel_signal           :: otel_signal(),
+               %% for future extensions
+               cb_module             :: module(),
+               %% Arbitrary config of the callback module
+               external_config       :: term(),
+               extra                 = [] %% Unused, for future extensions
+              }).
+
+%%--------------------------------------------------------------------
+%% Test utils
+%%--------------------------------------------------------------------
+
+-ifdef(TEST).
+-export([current_tab_to_list/1]).
+current_tab_to_list(RegName) ->
+    {_, #data{tables=Tabs, atomic_ref=AtomicRef}} = sys:get_state(RegName),
+    case ?current_tab(AtomicRef) of
+        0 -> [];
+        TabIx -> ets:tab2list(?tab_name(TabIx, Tabs))
+    end.
+-endif.
+
+%%--------------------------------------------------------------------
+%% otel_batch_olp API
+%%--------------------------------------------------------------------
+
+-spec init_conf(otel_batch_olp_config()) -> {ok, otel_batch_olp_state()} | {error, term()}.
+init_conf(#{reg_name := RegName, cb_module := _Module, otel_signal := _, exporter := _,
+            max_queue_size := _, exporting_timeout_ms := _, scheduled_delay_ms := _} = Config) ->
+    case validate_config(Config) of
+        ok ->
+            AtomicRef = atomics:new(3, [{signed, true}]),
+            {ok, Config#{reg_name => RegName,
+                          tables => {?table_1(RegName), ?table_2(RegName)},
+                          atomic_ref => AtomicRef}};
+        Err ->
+            Err
+    end.
+-spec start_link(otel_batch_olp_state(), term()) -> gen_statem:start_ret().
+start_link(#{reg_name := RegName} = OlpState, ExternalConfig) ->
+    gen_statem:start_link({local, RegName}, ?MODULE, [OlpState, ExternalConfig], []).
+
+-spec insert_signal(tuple(), otel_batch_olp_state()) -> true | dropped | {error, term()}.
+insert_signal(Record, #{atomic_ref := AtomicRef, tables := Tabs} = State) ->
+    try
+        case ?current_tab(AtomicRef) of
+            0 -> dropped;
+            CurrentTab ->
+                case ?sub_get_available(AtomicRef, CurrentTab) of
+                    Seq when Seq > 0 ->
+                        ets:insert(?tab_name(CurrentTab, Tabs), Record);
+                    0 ->
+                        %% max_queue_size is reached
+                        Res = ets:insert(?tab_name(CurrentTab, Tabs), Record),
+                        _ = force_flush(State),
+                        Res;
+                    _ ->
+                        dropped
+                end
+        end
+    catch
+        error:badarg ->
+            {error, {no_otel_batch_olp, maps:get(otel_signal, State, undefined)}};
+        Err:Reason ->
+            {error, {Err, Reason}}
+    end.
+
+-spec force_flush(otel_batch_olp_state()) -> ok.
+force_flush(#{reg_name := RegName}) ->
+    gen_statem:cast(RegName, force_flush).
+
+-spec change_config(OldConfigState, NewConfig, NewExtConfig) ->
+          {ok, NewConfigState} | {error, Reason} when
+      OldConfigState :: otel_batch_olp_state(),
+      NewConfig :: otel_batch_olp_config(),
+      NewExtConfig :: term(),
+      NewConfigState :: otel_batch_olp_state(),
+      Reason :: term().
+change_config(#{reg_name := RegName}, #{reg_name := RegName1}, _) when RegName =/= RegName1 ->
+    ?private_field_err(reg_name);
+change_config(#{atomic_ref := Ref}, #{atomic_ref := Ref1}, _) when Ref =/= Ref1 ->
+    ?private_field_err(atomic_ref);
+change_config(#{tables := Tabs}, #{tables := Tabs1}, _) when Tabs =/= Tabs1 ->
+    ?private_field_err(tables);
+%% Changing timeout or exporter config requires restart/re-initialiazation of exporter,
+%% which is not supported now. If timeout or exporter needs to be changed,
+%% the handler should be stopped and started with the new config
+change_config(#{exporter := Exporter}, #{exporter := Exporter1}, _) when Exporter =/= Exporter1 ->
+    ?change_not_allowed_err(exporter);
+change_config(#{exporting_timeout_ms := T}, #{exporting_timeout_ms := T1}, _) when T =/= T1 ->
+    ?change_not_allowed_err(exporting_timeout_ms);
+change_config(#{reg_name := RegName} = OldConfig, NewConfig, NewExtConfig) ->
+    case validate_config(NewConfig) of
+        ok ->
+            %% This is necessary, so that the config returned to the caller
+            %% contains alls the immutable keys required to communicate with
+            %% otel_batch_olp
+            NewConfig1 = copy_required_fields(OldConfig, NewConfig),
+            gen_statem:call(RegName, {change_config, NewConfig1, NewExtConfig});
+        Err ->
+            Err
+    end.
+
+%%--------------------------------------------------------------------
+%% gen_statem callbacks
+%%--------------------------------------------------------------------
+
+init([OlpState, ExtConfig]) ->
+    #{atomic_ref := AtomicRef,
+      reg_name := RegName,
+      tables := {Tab1, Tab2},
+      cb_module := CbModule,
+      otel_signal := OtelSignal,
+      max_queue_size := MaxQueueSize,
+      scheduled_delay_ms := ScheduledDelay,
+      exporting_timeout_ms := ExportTimeoutMs,
+      exporter := ExporterConfig
+     } = OlpState,
+    process_flag(trap_exit, true),
+    Resource = maps:get(resource, OlpState, otel_resource_detector:get_resource()),
+    ExporterConfig1 = exporter_conf_with_timeout(ExporterConfig, ExportTimeoutMs),
+
+    %% assert table names match
+    Tab1 = ?table_1(RegName),
+    Tab2 = ?table_2(RegName),
+
+    ExtraEtsOpts = maps:get(extra_ets_opts, OlpState, []),
+    _Tid1 = new_export_table(Tab1, ExtraEtsOpts),
+    _Tid2 = new_export_table(Tab2, ExtraEtsOpts),
+
+    %% This is sligthly increased, to give the exporter runner a chance to  garcefully time-out
+    %% before being killed by the handler.
+    ExportTimeoutMs1 = ExportTimeoutMs + 1000,
+
+    Data = #data{atomic_ref=AtomicRef,
+                 exporter=undefined,
+                 exporter_config=ExporterConfig1,
+                 otel_signal = OtelSignal,
+                 resource=Resource,
+                 tables={Tab1, Tab2},
+                 reg_name=RegName,
+                 cb_module = CbModule,
+                 exporting_timeout_ms=ExportTimeoutMs1,
+                 scheduled_delay_ms=ScheduledDelay,
+                 shutdown_ms = maps:get(shutdown_timeout_ms, OlpState, ?DEFAULT_SHUTDOWN_MS),
+                 max_queue_size=size_limit(MaxQueueSize),
+                 external_config=ExtConfig},
+    %% Also used in change_config API, thus mutable
+    Data1 = add_mutable_config_to_data(OlpState, ExtConfig, Data),
+
+    ?set_current_tab(AtomicRef, ?TAB_1_IX),
+    ?set_available(AtomicRef, ?TAB_1_IX, Data1#data.max_queue_size),
+    ?set_available(AtomicRef, ?TAB_2_IX, Data1#data.max_queue_size),
+
+    {ok, init_exporter, Data1}.
+
+callback_mode() ->
+    [state_functions, state_enter].
+
+%% TODO: handle exporter crashes and re-init it.
+%% This is not expected to happen with the default grpc opentelemetry_exporter,
+%% as it keeps running and retrying by itself in case of network failures.
+init_exporter(enter, _OldState, _Data) ->
+    {keep_state_and_data, [{state_timeout, 0, do_init_exporter}]};
+init_exporter(_, do_init_exporter, Data=#data{exporter_config=ExporterConfig,
+                                              atomic_ref=AtomicRef,
+                                              tables=Tabs,
+                                              scheduled_delay_ms=SendInterval,
+                                              reg_name=RegName,
+                                              otel_signal=Signal}) ->
+    case do_init_exporter(Signal, RegName, ExporterConfig) of
+        %% error should be retried
+        error ->
+            {keep_state_and_data, [{state_timeout, SendInterval, do_init_exporter}]};
+        ignore ->
+            %% no exporter: disable the insertion of new log events and delete the current table
+            clear_table_and_disable(AtomicRef, Tabs),
+            {next_state, idle, Data#data{exporter=ignore}};
+        Exporter ->
+            TimerRef = start_exporting_timer(SendInterval),
+            {next_state, idle, Data#data{exporter=Exporter, exporter_timer=TimerRef}}
+    end;
+init_exporter(_, _, _) ->
+    %% Ignore any other, e.g, external events like force_flush in this state
+    keep_state_and_data.
+
+idle(enter, _OldState, _Data) ->
+    keep_state_and_data;
+idle(info, {timeout, Ref, export_signals}, Data=#data{exporter_timer=Ref}) ->
+    {next_state, exporting, Data};
+idle(cast, force_flush, #data{exporter=Exporter}=Data) when Exporter =/= ignore ->
+    {next_state, exporting, Data};
+idle(EventType, EventContent, Data) ->
+    handle_event_(idle, EventType, EventContent, Data).
+
+exporting(info, {timeout, Ref, export_signals}, #data{exporter_timer=Ref}) ->
+    {keep_state_and_data, [postpone]};
+exporting(enter, _OldState, Data=#data{atomic_ref=AtomicRef,
+                                       tables=Tabs,
+                                       max_queue_size=MaxSize,
+                                       exporting_timeout_ms=ExportingTimeout,
+                                       scheduled_delay_ms=SendInterval}) ->
+    CurrentTab = ?current_tab(AtomicRef),
+    {Data1, Actions} =
+        case ?get_available(AtomicRef, CurrentTab) of
+            %% No events yet, maximum available capacity, nothing to export
+            MaxSize ->
+                %% The other table may contain residual (late) writes not exported
+                %% during the previous run. If current table is not empty, we don't
+                %% need to check the size of the previous (currently disabled) table,
+                %% since we will switch to it after this exporter run.
+                %% However, if current table remains empty for a long time,
+                %% neither export nor table switch will be triggered, and any
+                %% residual late log events in the previous table would be left
+                %% dangling. To avoid such cases, we check other table size
+                %% and export it if it's not empty.
+                maybe_export_other_table(CurrentTab, Data);
+            _ ->
+                RunnerPidRef = export_signals(CurrentTab, Data),
+                {Data#data{runner=RunnerPidRef,
+                           handed_off_table=?tab_name(CurrentTab, Tabs)},
+                 [{state_timeout, ExportingTimeout, exporting_timeout}]}
+        end,
+    {keep_state, Data1#data{exporter_timer = start_exporting_timer(SendInterval)}, Actions};
+exporting(state_timeout, empty_table, Data) ->
+    {next_state, idle, Data};
+exporting(state_timeout, exporting_timeout, Data) ->
+    %% kill current exporting process because it is taking too long
+    Data1 = kill_runner(Data),
+    {next_state, idle, Data1};
+%% Exit reason is ignored, since we don't handle exporter failures specifically for now
+exporting(info, {'DOWN', Ref, process, Pid, _Info}, Data=#data{runner={Pid, Ref}}) ->
+    complete_exporting(Data);
+exporting(EventType, Event, Data) ->
+    handle_event_(exporting, EventType, Event, Data).
+
+terminate(_Reason, _State, #data{exporter=ignore}) ->
+    ok;
+terminate(_Reason, State, Data=#data{exporter=Exporter,
+                                     resource=Resource,
+                                     external_config=ExtConfig,
+                                     atomic_ref=AtomicRef,
+                                     tables={Tab1, Tab2},
+                                     shutdown_ms=ShutdownMs,
+                                     otel_signal=Signal
+                                    }) ->
+    ?disable(AtomicRef),
+    T0 = ?time_ms,
+    _ = maybe_wait_for_current_runner(State, Data, ShutdownMs),
+    T1 = ?time_ms,
+
+    %% Check both tables as each one may have some late unexported signals data.
+    %% NOTE: exports are attempted sequentially to follow the specification restriction:
+    %% "Export will never be called concurrently for the same exporter instance"
+    %% (see: https://opentelemetry.io/docs/specs/otel/logs/sdk/#export).
+    RemTime = ?rem_time(ShutdownMs, T0, T1),
+    ets:info(Tab1, size) > 0
+        andalso export_and_wait(Exporter, Resource, Tab1, ExtConfig, RemTime, Signal),
+    T2 = ?time_ms,
+    RemTime1 = ?rem_time(RemTime, T1, T2),
+    ets:info(Tab2, size) > 0
+        andalso export_and_wait(Exporter, Resource, Tab2, ExtConfig, RemTime1, Signal),
+
+    _ = otel_exporter:shutdown(Exporter),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+handle_event_(_State, {call, From}, {change_config, NewConfig, NewExtConfig}, Data) ->
+    {keep_state,
+     add_mutable_config_to_data(NewConfig, NewExtConfig, Data),
+     [{reply, From, {ok, NewConfig}}]};
+handle_event_(_State, info, {'EXIT', _Pid, Reason}, _Data)  ->
+    %% This can be a linked exporter process, unless someone linked to the handler process,
+    %% or explicitly called exit(HandlerPid, Reason)
+    %% This will call terminate/3 and may try to export current log events,
+    %% even if the linked exporter process is down.
+    %% This is safe, though, as all errors of otel_exporter:export/5 are caught.
+    {stop, Reason};
+handle_event_(_State, _, _, _) ->
+    keep_state_and_data.
+
+do_init_exporter(Signal, RegName, ExporterConfig) ->
+    %% It's crucial to attempt starting opentelemetry_exporter in post init stage,
+    %% when otel_batch_olp has been already started (its `init/1` returned).
+    %% The reason is that it can called by logger:adding_handler/1 cb causing a deadlock
+    %% with ssl app (opentelemetry_exporter dependency), if ssl app has not been started previously.
+    _ = application:ensure_all_started(opentelemetry_exporter),
+    otel_exporter:init(Signal, RegName, ExporterConfig).
+
+start_exporting_timer(SendInterval) ->
+    erlang:start_timer(SendInterval, self(), export_signals).
+
+maybe_export_other_table(CurrentTab, Data=#data{tables=Tabs,
+                                                exporting_timeout_ms=ExportingTimeout}) ->
+    NextTab = ?next_tab(CurrentTab),
+    %% Check ETS size instead of the counter, as late writes can't be detected with the atomic counter
+    case ets:info(?tab_name(NextTab, Tabs), size) of
+        0 ->
+            %% in an `enter' handler we can't return a `next_state' or `next_event'
+            %% so we rely on a timeout to trigger the transition to `idle'
+            {Data#data{runner=undefined}, [{state_timeout, 0, empty_table}]};
+        _ ->
+            RunnerPid = export_signals(NextTab, Data),
+            {Data#data{runner=RunnerPid, handed_off_table=?tab_name(CurrentTab, Tabs)},
+             [{state_timeout, ExportingTimeout, exporting_timeout}]}
+    end.
+
+export_signals(CurrentTab, #data{exporter=Exporter,
+                                 max_queue_size=MaxSize,
+                                 resource=Resource,
+                                 atomic_ref=AtomicRef,
+                                 tables=Tabs,
+                                 external_config=ExtConfig,
+                                 otel_signal=Signal}) ->
+
+    NewCurrentTab = ?next_tab(CurrentTab),
+    %% the new table is expected to be empty or hold a few late writes from the previous export,
+    %% so it safe to set available max size
+    ?set_available(AtomicRef, NewCurrentTab, MaxSize),
+    ?set_current_tab(AtomicRef, NewCurrentTab),
+    export_async(Exporter, Resource, ?tab_name(CurrentTab, Tabs), ExtConfig, Signal).
+
+export_async(Exporter, Resource, CurrentTab, ExtConfig, Signal) ->
+    erlang:spawn_monitor(fun() -> export(Exporter, Resource, CurrentTab, ExtConfig, Signal) end).
+
+export(undefined, _, _, _, _) ->
+    true;
+export({ExporterModule, ExporterState}, Resource, Tab, ExtConfig, Signal) ->
+    try
+        %% TODO: API for both signals should probably be aligned in otel_exporter
+        TabOrTabConfig = case Signal of
+                             traces -> Tab;
+                             logs -> {Tab, ExtConfig}
+                         end,
+        %% we ignore values, as no retries mechanism, is implemented
+        otel_exporter:export(Signal, ExporterModule, TabOrTabConfig, Resource, ExporterState)
+    catch
+        Class:Reason:St ->
+            %% Other logger handler(s) (e.g. default) should be enabled, so that
+            %% log events produced by otel_log_handler are not lost in case otel_log_handler
+            %% is not functioning properly.
+            ?LOG_ERROR("~p exporter ~p failed with exception: ~p:~p, stacktrace: ~p",
+                       [Signal, Class, Reason, otel_utils:stack_without_args(St)]),
+            error
+    end.
+
+new_export_table(Name, ExtraEtsOpts) ->
+    %% log event timestamps used as keys are not guaranteed to always be unique,
+    %% so we use duplicate_bag
+    %% Using timestamps as keys instead of instrumentation scopes is expected
+    %% to have higher entropy which should improve write concurrency
+    Opts = lists:usort([public,
+                        named_table,
+                        {write_concurrency, true},
+                        duplicate_bag] ++ ExtraEtsOpts),
+    ets:new(Name, Opts).
+
+clear_table_and_disable(AtomicRef, Tabs) ->
+    case ?current_tab(AtomicRef) of
+        0 ->
+            %% already disabled
+            ok;
+        CurrentTab ->
+            ?disable(AtomicRef),
+            CurrentTabName = ?tab_name(CurrentTab, Tabs),
+            ets:delete_all_objects(CurrentTabName),
+            ok
+    end.
+
+complete_exporting(Data) ->
+    {next_state, idle, Data#data{runner=undefined,
+                                 handed_off_table=undefined}}.
+
+kill_runner(Data=#data{runner={RunnerPid, Ref}, handed_off_table=Tab}) ->
+    _ = erlang:demonitor(Ref),
+    %% NOTE: `exit/2` is async, but as we don't delete/recreate export tables,
+    %% we don't need to wait for runner termination
+    erlang:exit(RunnerPid, kill),
+    _ = ets:delete_all_objects(Tab),
+    Data#data{runner=undefined, handed_off_table=undefined};
+kill_runner(Data=#data{runner=undefined}) ->
+    Data.
+
+exporter_conf_with_timeout({?DEFAULT_EXPORTER_MODULE, Conf}, TimeoutMs) ->
+    {?DEFAULT_EXPORTER_MODULE, Conf#{timeout_ms => TimeoutMs}};
+exporter_conf_with_timeout(OtherExporter, _Timeout) ->
+    OtherExporter.
+
+%% terminate/3 helpers
+
+export_and_wait(Exporter, Resource, Tab, Config, Timeout, Signal) ->
+    RunnerPidRef = export_async(Exporter, Resource, Tab, Config, Signal),
+    wait_for_runner(RunnerPidRef, Timeout).
+
+wait_for_runner({RunnerPid, RunnerRef}, Timeout) ->
+    receive
+        {'DOWN', RunnerRef, process, RunnerPid, _Info} -> ok
+    after Timeout ->
+            erlang:demonitor(RunnerRef),
+            erlang:exit(RunnerPid, kill),
+            ok
+    end.
+
+maybe_wait_for_current_runner(exporting, #data{runner={Pid, Ref}}, Timeout) ->
+    wait_for_runner({Pid, Ref}, Timeout);
+maybe_wait_for_current_runner(_State, _Date, _Timeout) -> ok.
+
+%% Config helpers
+
+validate_config(Config) ->
+    Errs = maps:fold(fun(K, Val, Acc) ->
+                             case validate_opt(K, Val, Config) of
+                                 ok -> Acc;
+                                 Err -> [Err | Acc]
+                             end
+              end,
+                     [], Config),
+    case Errs of
+        [] -> ok;
+        _ -> {error, Errs}
+    end.
+
+validate_opt(max_queue_size, infinity, _Config) ->
+    ok;
+validate_opt(K, Val, _Config) when is_integer(Val), Val > 0,
+                                   K =:= max_queue_size;
+                                   K =:= exporting_timeout_ms;
+                                   K =:= scheduled_delay_ms;
+                                   K =:= shutdown_timeout_ms ->
+    ok;
+validate_opt(exporter, {Module, _}, _Config) when is_atom(Module) ->
+    ok;
+validate_opt(exporter, Module, _Config) when is_atom(Module) ->
+    ok;
+validate_opt(otel_signal, Signal, _Config) when Signal =:= traces; Signal =:= logs ->
+    ok;
+validate_opt(cb_module, Module, _Config) ->
+    Module:module_info(),
+    ok;
+validate_opt(extra_ets_opts, [{keypos, Pos}], _Config) when Pos >= 1 ->
+    ok;
+validate_opt(extra_ets_opts, [], _Config) ->
+    ok;
+validate_opt(reg_name, RegName, _Config) when is_atom(RegName) ->
+    ok;
+validate_opt(resource, Resource, _Config) when is_tuple(Resource) ->
+    ok;
+validate_opt(K, Val, _Config) ->
+    {invalid_config, K, Val}.
+
+add_mutable_config_to_data(Config, ExtConfig, Data) ->
+    #{max_queue_size:=SizeLimit,
+      scheduled_delay_ms:=ScheduledDelay
+     } = Config,
+    Data#data{max_queue_size=size_limit(SizeLimit),
+              scheduled_delay_ms=ScheduledDelay,
+              external_config=ExtConfig}.
+
+%% high enough, must be infeasible to reach
+size_limit(infinity) ->
+    ?MAX_SIGNED_INT;
+size_limit(Int) ->
+    Int.
+
+copy_required_fields(OldConf, NewConf) ->
+    #{reg_name := RegName,
+      otel_signal := Signal,
+      tables := Tabs,
+      atomic_ref := AtomicRef} = OldConf,
+    NewConf#{reg_name => RegName,
+             otel_signal => Signal,
+             tables => Tabs,
+             atomic_ref => AtomicRef}.

--- a/apps/opentelemetry/src/otel_batch_processor.erl
+++ b/apps/opentelemetry/src/otel_batch_processor.erl
@@ -27,431 +27,79 @@
 %%%-----------------------------------------------------------------------
 -module(otel_batch_processor).
 
--behaviour(gen_statem).
+
 -behaviour(otel_span_processor).
 
 -export([start_link/1,
          on_start/3,
          on_end/2,
-         force_flush/1,
-         report_cb/1,
-
-         %% deprecated
-         set_exporter/1,
-         set_exporter/2,
-         set_exporter/3]).
-
--export([init/1,
-         callback_mode/0,
-         idle/3,
-         exporting/3,
-         terminate/3]).
-
-%% uncomment when OTP-23 becomes the minimum required version
-%% -deprecated({set_exporter, 1, "set through the otel_tracer_provider instead"}).
-%% -deprecated({set_exporter, 2, "set through the otel_tracer_provider instead"}).
-%% -deprecated({set_exporter, 3, "set through the otel_tracer_provider instead"}).
+         force_flush/1]).
 
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
 -include_lib("kernel/include/logger.hrl").
 -include("otel_span.hrl").
 
--record(data, {exporter             :: {module(), term()} | undefined,
-               exporter_config      :: {module(), term()} | undefined | none,
-               resource             :: otel_resource:t() | undefined,
-               handed_off_table     :: atom() | undefined,
-               runner_pid           :: pid() | undefined,
-               max_queue_size       :: integer() | infinity,
-               exporting_timeout_ms :: integer(),
-               check_table_size_ms  :: integer() | infinity,
-               scheduled_delay_ms   :: integer(),
-               table_1              :: atom(),
-               table_2              :: atom(),
-               reg_name             :: atom()}).
-
--define(CURRENT_TABLES_KEY(Name), {?MODULE, current_table, Name}).
-
-%% create unique table names to support multiple batch processors at once
--define(TABLE_NAME(TN), lists:concat([TN, "_", erlang:pid_to_list(self())])).
--define(TABLE_1, ?REG_NAME(?TABLE_NAME(otel_export_table1))).
--define(TABLE_2, ?REG_NAME(?TABLE_NAME(otel_export_table2))).
--define(CURRENT_TABLE(RegName), persistent_term:get(?CURRENT_TABLES_KEY(RegName))).
+-type batch_processor_config() ::
+        #{name := atom(),
+          max_queue_size => otel_batch_olp:max_queue_size(),
+          exporting_timeout_ms => otel_batch_olp:otel_timeout_ms(),
+          scheduled_delay_ms => otel_batch_olp:otel_timeout_ms(),
+          exporter => otel_exporter:exporter_config()}.
 
 -define(DEFAULT_MAX_QUEUE_SIZE, 2048).
 -define(DEFAULT_SCHEDULED_DELAY_MS, timer:seconds(5)).
--define(DEFAULT_EXPORTER_TIMEOUT_MS, timer:minutes(5)).
--define(DEFAULT_CHECK_TABLE_SIZE_MS, timer:seconds(1)).
+-define(DEFAULT_EXPORTER_TIMEOUT_MS, timer:seconds(30)).
+-define(DEFAULT_EXPORTER_MODULE, opentelemetry_exporter).
+-define(DEFAULT_EXPORTER, {?DEFAULT_EXPORTER_MODULE, #{}}).
 
--define(ENABLED_KEY(RegName), {?MODULE, enabled_key, RegName}).
-
--ifdef(TEST).
--export([current_tab_to_list/1]).
-current_tab_to_list(RegName) ->
-    ets:tab2list(?CURRENT_TABLE(RegName)).
--endif.
-
-start_link(Config) ->
-    Name = case maps:find(name, Config) of
-               {ok, N} ->
-                   N;
-               error ->
-                   %% use a unique reference to distiguish multiple batch processors while
-                   %% still having a single name, instead of a possibly changing pid, to
-                   %% communicate with the processor
-                   erlang:ref_to_list(erlang:make_ref())
-           end,
-
-    RegisterName = ?REG_NAME(Name),
-    Config1 = Config#{reg_name => RegisterName},
-    {ok, Pid} = gen_statem:start_link({local, RegisterName}, ?MODULE, [Config1], []),
-    {ok, Pid, Config1}.
-
-%% @deprecated Please use {@link otel_tracer_provider}
-set_exporter(Exporter) ->
-    set_exporter(global, Exporter, []).
-
-%% @deprecated Please use {@link otel_tracer_provider}
--spec set_exporter(module(), term()) -> ok.
-set_exporter(Exporter, Options) ->
-    %% eqwalizer:ignore doesn't like gen_`statem:call' returns `term()'
-    gen_statem:call(?REG_NAME(global), {set_exporter, {Exporter, Options}}).
-
-%% @deprecated Please use {@link otel_tracer_provider}
--spec set_exporter(atom(), module(), term()) -> ok.
-set_exporter(Name, Exporter, Options) ->
-    %% eqwalizer:ignore doesn't like gen_`statem:call' returns `term()'
-    gen_statem:call(?REG_NAME(Name), {set_exporter, {Exporter, Options}}).
+-spec start_link(batch_processor_config()) ->
+          {ok, pid(), otel_batch_olp:otel_batch_olp_state()} | {error, term()}.
+start_link(#{name := Name} = Config) ->
+    %% TODO: resource should be passed in from the tracer server, now it is detectd by otel_batch_olp
+    Config1 = maps:merge(default_config(), maps:remove(name, Config)),
+    Config2 = Config1#{reg_name => ?REG_NAME(Name),
+                       cb_module => ?MODULE,
+                       otel_signal => traces,
+                       %% trace_id is expected to have high entropy and, thus, can improve concurrency,
+                       %% it is not unique per span,  but it doesn't matter as the table type
+                       %% is `duplicate_bag`
+                       extra_ets_opts => [{keypos, #span.trace_id}]},
+    case otel_batch_olp:init_conf(Config2) of
+        {ok, OlpState} ->
+            case otel_batch_olp:start_link(OlpState, Config) of
+                {ok, Pid} ->
+                    {ok, Pid, OlpState};
+                Err ->
+                    Err
+            end;
+        Err ->
+            Err
+    end.
 
 -spec on_start(otel_ctx:t(), opentelemetry:span(), otel_span_processor:processor_config())
               -> opentelemetry:span().
 on_start(_Ctx, Span, _) ->
     Span.
 
--spec on_end(opentelemetry:span(), otel_span_processor:processor_config())
-            -> true | dropped | {error, invalid_span} | {error, no_export_buffer}.
+-spec on_end(opentelemetry:span(),  otel_batch_olp:otel_batch_olp_state()) ->
+          true | dropped | {error, term()}.
 on_end(#span{trace_flags=TraceFlags}, _) when not(?IS_SAMPLED(TraceFlags)) ->
     dropped;
-on_end(Span=#span{}, #{reg_name := RegName}) ->
-    do_insert(RegName, Span);
+on_end(Span=#span{}, Config) ->
+    otel_batch_olp:insert_signal(Span, Config);
 on_end(_Span, _) ->
     {error, invalid_span}.
 
--spec force_flush(#{reg_name := gen_statem:server_ref()}) -> ok.
-force_flush(#{reg_name := RegName}) ->
-    gen_statem:cast(RegName, force_flush).
+-spec force_flush(otel_batch_olp:otel_batch_olp_state()) -> ok.
+force_flush(Config) ->
+    otel_batch_olp:force_flush(Config).
 
-init([Args=#{reg_name := RegName}]) ->
-    process_flag(trap_exit, true),
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
 
-    SizeLimit = maps:get(max_queue_size, Args, ?DEFAULT_MAX_QUEUE_SIZE),
-    ExportingTimeout = maps:get(exporting_timeout_ms, Args, ?DEFAULT_EXPORTER_TIMEOUT_MS),
-    ScheduledDelay = maps:get(scheduled_delay_ms, Args, ?DEFAULT_SCHEDULED_DELAY_MS),
-    CheckTableSize = maps:get(check_table_size_ms, Args, ?DEFAULT_CHECK_TABLE_SIZE_MS),
-
-    %% TODO: this should be passed in from the tracer server
-    Resource = case maps:find(resource, Args) of
-                   {ok, R} ->
-                       R;
-                   error ->
-                       otel_resource_detector:get_resource()
-               end,
-    %% Resource = otel_tracer_provider:resource(),
-
-    Table1 = ?TABLE_1,
-    Table2 = ?TABLE_2,
-
-    _Tid1 = new_export_table(Table1),
-    _Tid2 = new_export_table(Table2),
-    persistent_term:put(?CURRENT_TABLES_KEY(RegName), Table1),
-
-    %% only enable export table if there is going to be an exporter
-    case maps:get(exporter, Args, none) of
-        ExporterConfig when ExporterConfig =:= none ; ExporterConfig =:= undefined ->
-            disable(RegName);
-        ExporterConfig ->
-            enable(RegName)
-    end,
-
-    {ok, idle, #data{exporter=undefined,
-                     exporter_config=ExporterConfig,
-                     resource = Resource,
-                     handed_off_table=undefined,
-                     max_queue_size=SizeLimit,
-                     exporting_timeout_ms=ExportingTimeout,
-                     check_table_size_ms=CheckTableSize,
-                     scheduled_delay_ms=ScheduledDelay,
-                     table_1=Table1,
-                     table_2=Table2,
-                     reg_name=RegName}}.
-
-callback_mode() ->
-    [state_functions, state_enter].
-
-idle(enter, _OldState, Data=#data{exporter=undefined,
-                                  exporter_config=ExporterConfig,
-                                  scheduled_delay_ms=SendInterval,
-                                  check_table_size_ms=CheckInterval,
-                                  reg_name=RegName}) ->
-    Exporter = init_exporter(RegName, ExporterConfig),
-    {keep_state, Data#data{exporter=Exporter},
-     [{{timeout, export_spans}, SendInterval, export_spans},
-      {{timeout, check_table_size}, CheckInterval, check_table_size}]};
-idle(enter, _OldState, #data{scheduled_delay_ms=SendInterval,
-                             check_table_size_ms=CheckInterval}) ->
-    {keep_state_and_data,
-     [{{timeout, export_spans}, SendInterval, export_spans},
-      {{timeout, check_table_size}, CheckInterval, check_table_size}]};
-idle(_, export_spans, Data=#data{exporter=undefined,
-                                 exporter_config=ExporterConfig,
-                                 reg_name=RegName}) ->
-    Exporter = init_exporter(RegName, ExporterConfig),
-    {next_state, exporting, Data#data{exporter=Exporter}};
-idle(_, export_spans, Data) ->
-    {next_state, exporting, Data};
-idle(EventType, Event, Data) ->
-    handle_event_(idle, EventType, Event, Data).
-
-%% receiving an `export_spans' timeout while exporting means the `ExportingTimeout'
-%% is shorter than the `SendInterval'. Postponing the event will ensure we export
-%% after
-exporting({timeout, export_spans}, export_spans, _) ->
-    {keep_state_and_data, [postpone]};
-exporting(enter, _OldState, #data{exporter=undefined,
-                                  reg_name=RegName}) ->
-    %% exporter still undefined, go back to idle
-    %% first empty the table and disable the processor so no more spans are added
-    %% we wait until the attempt to export to disable so we don't lose spans
-    %% on startup but disable once it is clear an exporter isn't being set
-    clear_table_and_disable(RegName),
-
-    %% use state timeout to transition to `idle' since we can't set a
-    %% new state in an `enter' handler
-    {keep_state_and_data, [{state_timeout, 0, no_exporter}]};
-exporting(enter, _OldState, Data=#data{exporting_timeout_ms=ExportingTimeout,
-                                       scheduled_delay_ms=SendInterval}) ->
-    case export_spans(Data) of
-        ok ->
-            %% in an `enter' handler we can't return a `next_state' or `next_event'
-            %% so we rely on a timeout to trigger the transition to `idle'
-            {keep_state, Data#data{runner_pid=undefined}, [{state_timeout, 0, empty_table}]};
-        {OldTableName, RunnerPid} ->
-            {keep_state, Data#data{runner_pid=RunnerPid,
-                                   handed_off_table=OldTableName},
-             [{state_timeout, ExportingTimeout, exporting_timeout},
-              {{timeout, export_spans}, SendInterval, export_spans}]}
-    end;
-
-%% TODO: we need to just check if `exporter=undefined' right?
-%% two hacks since we can't transition to a new state or send an action from `enter'
-exporting(state_timeout, no_exporter, Data) ->
-    {next_state, idle, Data};
-exporting(state_timeout, empty_table, Data) ->
-    {next_state, idle, Data};
-
-exporting(state_timeout, exporting_timeout, Data=#data{handed_off_table=ExportingTable}) ->
-    %% kill current exporting process because it is taking too long
-    %% which deletes the exporting table, so create a new one and
-    %% repeat the state to force another span exporting immediately
-    Data1 = kill_runner(Data),
-    new_export_table(ExportingTable),
-    {next_state, idle, Data1};
-%% important to verify runner_pid and FromPid are the same in case it was sent
-%% after kill_runner was called but before it had done the unlink
-exporting(info, {'EXIT', FromPid, _}, Data=#data{runner_pid=FromPid}) ->
-    complete_exporting(Data);
-%% important to verify runner_pid and FromPid are the same in case it was sent
-%% after kill_runner was called but before it had done the unlink
-exporting(info, {completed, FromPid}, Data=#data{runner_pid=FromPid}) ->
-    complete_exporting(Data);
-exporting(EventType, Event, Data) ->
-    handle_event_(exporting, EventType, Event, Data).
-
-%% transition to exporting on a force_flush unless we are already exporting
-%% if exporting then postpone the event so the force flush happens after
-%% this current exporting is complete
-handle_event_(exporting, _, force_flush, _Data) ->
-    {keep_state_and_data, [postpone]};
-handle_event_(_State, _, force_flush, Data) ->
-    {next_state, exporting, Data};
-
-handle_event_(_State, {timeout, check_table_size}, check_table_size, #data{max_queue_size=infinity}) ->
-    keep_state_and_data;
-handle_event_(_State, {timeout, check_table_size}, check_table_size, #data{max_queue_size=MaxQueueSize,
-                                                                           check_table_size_ms=CheckInterval,
-                                                                           reg_name=RegName}) ->
-    case ets:info(?CURRENT_TABLE(RegName), size) of
-        M when M >= MaxQueueSize ->
-            disable(RegName);
-        _ ->
-            enable(RegName)
-    end,
-    {keep_state_and_data, [{{timeout, check_table_size}, CheckInterval, check_table_size}]};
-handle_event_(_, {call, From}, {set_exporter, ExporterConfig}, Data=#data{exporter=OldExporter,
-                                                                          reg_name=RegName}) ->
-    otel_exporter:shutdown(OldExporter),
-
-    %% enable immediately or else spans will be dropped for a period even after this call returns
-    enable(RegName),
-
-    {keep_state, Data#data{exporter=undefined,
-                           exporter_config=ExporterConfig}, [{reply, From, ok},
-                                                             {next_event, internal, init_exporter}]};
-handle_event_(_, internal, init_exporter, Data=#data{exporter=undefined,
-                                                     exporter_config=ExporterConfig,
-                                                     reg_name=RegName}) ->
-    Exporter = init_exporter(RegName, ExporterConfig),
-    {keep_state, Data#data{exporter=Exporter}};
-handle_event_(_, _, _, _) ->
-    keep_state_and_data.
-
-terminate(_Reason, _State, #data{exporter=Exporter,
-                                 resource=Resource,
-                                 reg_name=RegName}) ->
-    CurrentTable = ?CURRENT_TABLE(RegName),
-
-    %% `export' is used to perform a blocking export
-    _ = export(Exporter, Resource, CurrentTable),
-    otel_exporter:shutdown(Exporter),
-    ok.
-
-%%
-
-init_exporter(RegName, ExporterConfig) ->
-    case otel_exporter:init(traces, RegName, ExporterConfig) of
-        Exporter when Exporter =/= undefined andalso Exporter =/= none ->
-            enable(RegName),
-            Exporter;
-        _ ->
-            %% exporter is undefined/none
-            %% disable the insertion of new spans and delete the current table
-            clear_table_and_disable(RegName),
-            undefined
-    end.
-
-clear_table_and_disable(RegName) ->
-    disable(RegName),
-    ets:delete(?CURRENT_TABLE(RegName)),
-    new_export_table(?CURRENT_TABLE(RegName)).
-
-enable(RegName)->
-    persistent_term:put(?ENABLED_KEY(RegName), true).
-
-disable(RegName) ->
-    persistent_term:put(?ENABLED_KEY(RegName), false).
-
-is_enabled(RegName) ->
-    persistent_term:get(?ENABLED_KEY(RegName), true).
-
-do_insert(RegName, Span) ->
-    try
-        case is_enabled(RegName) of
-            true ->
-                ets:insert(?CURRENT_TABLE(RegName), Span);
-            _ ->
-                dropped
-        end
-    catch
-        error:badarg ->
-            {error, no_batch_span_processor};
-        _:_ ->
-            {error, other}
-    end.
-
-complete_exporting(Data=#data{handed_off_table=ExportingTable})
-  when ExportingTable =/= undefined ->
-    new_export_table(ExportingTable),
-    {next_state, idle, Data#data{runner_pid=undefined,
-                                 handed_off_table=undefined}};
-complete_exporting(Data) ->
-    {next_state, idle, Data#data{runner_pid=undefined,
-                                 handed_off_table=undefined}}.
-
-kill_runner(Data=#data{runner_pid=RunnerPid}) when RunnerPid =/= undefined ->
-    Mon = erlang:monitor(process, RunnerPid),
-    erlang:unlink(RunnerPid),
-    erlang:exit(RunnerPid, kill),
-    %% Wait for the runner process terminatation to be sure that
-    %% the export table is destroyed and can be safely recreated
-    receive
-        {'DOWN', Mon, process, RunnerPid, _} ->
-            Data#data{runner_pid=undefined, handed_off_table=undefined}
-    end.
-
-new_export_table(Name) ->
-     ets:new(Name, [public,
-                    named_table,
-                    {write_concurrency, true},
-                    duplicate_bag,
-                    %% OpenTelemetry exporter protos group by the
-                    %% instrumentation_scope. So using instrumentation_scope
-                    %% as the key means we can easily lookup all spans for
-                    %% for each instrumentation_scope and export together.
-                    {keypos, #span.instrumentation_scope}]).
-
-export_spans(#data{exporter=Exporter,
-                   resource=Resource,
-                   table_1=Table1,
-                   table_2=Table2,
-                   reg_name=RegName}) ->
-    CurrentTable = ?CURRENT_TABLE(RegName),
-    case ets:info(CurrentTable, size) of
-        0 ->
-            %% nothing to do if the table is empty
-            ok;
-        _ ->
-            NewCurrentTable = case CurrentTable of
-                                  Table1 ->
-                                      Table2;
-                                  Table2 ->
-                                      Table1
-                              end,
-
-            %% an atom is a single word so this does not trigger a global GC
-            persistent_term:put(?CURRENT_TABLES_KEY(RegName), NewCurrentTable),
-            %% set the table to accept inserts
-            enable(RegName),
-
-            Self = self(),
-            RunnerPid = erlang:spawn_link(fun() -> send_spans(Self, Resource, Exporter) end),
-            ets:give_away(CurrentTable, RunnerPid, export),
-            {CurrentTable, RunnerPid}
-    end.
-
-send_spans(FromPid, Resource, Exporter) ->
-    receive
-        {'ETS-TRANSFER', Table, FromPid, export} ->
-            export(Exporter, Resource, Table),
-            ets:delete(Table),
-            completed(FromPid)
-    end.
-
-completed(FromPid) ->
-    FromPid ! {completed, self()}.
-
-export(undefined, _, _) ->
-    true;
-export({ExporterModule, Config}, Resource, SpansTid) ->
-    %% don't let a exporter exception crash us
-    %% and return true if exporter failed
-    try
-        otel_exporter:export_traces(ExporterModule, SpansTid, Resource, Config)
-    catch
-        Kind:Reason:StackTrace ->
-            ?LOG_INFO(#{source => exporter,
-                        during => export,
-                        kind => Kind,
-                        reason => Reason,
-                        exporter => ExporterModule,
-                        stacktrace => StackTrace}, #{report_cb => fun ?MODULE:report_cb/1}),
-            true
-    end.
-
-%% logger format functions
-report_cb(#{source := exporter,
-            during := export,
-            kind := Kind,
-            reason := Reason,
-            exporter := ExporterModule,
-            stacktrace := StackTrace}) ->
-    {"span exporter threw exception: exporter=~p ~ts",
-     [ExporterModule, otel_utils:format_exception(Kind, Reason, StackTrace)]}.
+default_config() ->
+    #{max_queue_size => ?DEFAULT_MAX_QUEUE_SIZE,
+      exporting_timeout_ms => ?DEFAULT_EXPORTER_TIMEOUT_MS,
+      scheduled_delay_ms => ?DEFAULT_SCHEDULED_DELAY_MS,
+      exporter => ?DEFAULT_EXPORTER}.

--- a/apps/opentelemetry/src/otel_exporter_pid.erl
+++ b/apps/opentelemetry/src/otel_exporter_pid.erl
@@ -30,6 +30,7 @@ export(traces, SpansTid, _Resource, Pid) ->
     ets:foldl(fun(Span, _Acc) ->
                       Pid ! {span, Span}
               end, [], SpansTid),
+    ets:delete_all_objects(SpansTid),
     ok.
 
 shutdown(_) ->

--- a/apps/opentelemetry/src/otel_exporter_stdout.erl
+++ b/apps/opentelemetry/src/otel_exporter_stdout.erl
@@ -31,6 +31,7 @@ export(_, SpansTid, _Resource, _) ->
     ets:foldl(fun(Span, _Acc) ->
                       io:format("~p~n", [Span])
               end, [], SpansTid),
+    ets:delete_all_objects(SpansTid),
     ok.
 
 shutdown(_) ->

--- a/apps/opentelemetry/src/otel_exporter_tab.erl
+++ b/apps/opentelemetry/src/otel_exporter_tab.erl
@@ -30,6 +30,7 @@ export(traces, SpansTid, _Resource, Tid) ->
     ets:foldl(fun(Span, _Acc) ->
                       ets:insert(Tid, Span)
               end, [], SpansTid),
+    ets:delete_all_objects(SpansTid),
     ok.
 
 shutdown(_) ->

--- a/apps/opentelemetry/src/otel_span_limits.erl
+++ b/apps/opentelemetry/src/otel_span_limits.erl
@@ -25,7 +25,8 @@
          event_count_limit/0,
          link_count_limit/0,
          attribute_per_event_limit/0,
-         attribute_per_link_limit/0]).
+         attribute_per_link_limit/0,
+         cleanup_persistent_terms/0]).
 
 -include("otel_span.hrl").
 
@@ -33,7 +34,7 @@
 
 -spec get() -> #span_limits{}.
 get() ->
-    persistent_term:get(?SPAN_LIMITS_KEY).
+    persistent_term:get(?SPAN_LIMITS_KEY, #span_limits{}).
 
 -spec set(otel_configuration:t()) -> ok.
 set(#{attribute_count_limit := AttributeCountLimit,
@@ -80,3 +81,6 @@ get_limit(attribute_per_event_limit, #span_limits{attribute_per_event_limit=Attr
     AttributePerEventLimit;
 get_limit(attribute_per_link_limit, #span_limits{attribute_per_link_limit=AttributePerLinkLimit}) ->
     AttributePerLinkLimit.
+
+cleanup_persistent_terms() ->
+    otel_utils:cleanup_persistent_terms(?MODULE).

--- a/apps/opentelemetry/src/otel_span_processor.erl
+++ b/apps/opentelemetry/src/otel_span_processor.erl
@@ -28,8 +28,7 @@
 -callback on_start(otel_ctx:t(), opentelemetry:span(), processor_config()) -> opentelemetry:span().
 -callback on_end(opentelemetry:span(), processor_config()) -> true |
                                                               dropped |
-                                                              {error, invalid_span} |
-                                                              {error, no_export_buffer}.
+                                                              {error, term()}.
 -callback force_flush(processor_config()) -> ok |
                                              {error, term()}.
 

--- a/apps/opentelemetry/test/otel_batch_processor_SUITE.erl
+++ b/apps/opentelemetry/test/otel_batch_processor_SUITE.erl
@@ -10,6 +10,7 @@
 
 all() ->
     [exporting_timeout_test,
+     exporting_runner_timeout_test,
      check_table_size_test].
 
 %% verifies that after the runner has to be killed for taking too long
@@ -18,10 +19,10 @@ exporting_timeout_test(_Config) ->
     process_flag(trap_exit, true),
 
     {ok, Pid, _} = otel_batch_processor:start_link(#{name => test_processor,
-                                                     resource => otel_resource:create([]),
-                                                     exporter => ?MODULE,
-                                                     exporting_timeout_ms => 1,
-                                                     scheduled_delay_ms => 1}),
+                                                      resource => otel_resource:create([]),
+                                                      exporter => ?MODULE,
+                                                      exporting_timeout_ms => 1,
+                                                      scheduled_delay_ms => 1}),
 
     receive
         {'EXIT', Pid, _} ->
@@ -35,8 +36,8 @@ exporting_timeout_test(_Config) ->
 exporting_runner_timeout_test(_Config) ->
     process_flag(trap_exit, true),
 
-    {ok, Pid, #{reg_name := RegName}} = otel_batch_processor:start_link(
-                                          #{name => test_processor1,
+    {ok, Pid, State} = otel_batch_processor:start_link(
+                                          #{name => test_processor,
                                             resource => otel_resource:create([]),
                                             exporter => ?MODULE,
                                             exporting_timeout_ms => 1,
@@ -44,8 +45,8 @@ exporting_runner_timeout_test(_Config) ->
 
     %% Insert a few spans to make sure runner process will be spawned and killed
     %% because it hangs for 10 minutes (see export/4 below)
-    true = otel_batch_processor:on_end(generate_span(), #{reg_name => RegName}),
-    true = otel_batch_processor:on_end(generate_span(), #{reg_name => RegName}),
+    true = otel_batch_processor:on_end(generate_span(), State),
+    true = otel_batch_processor:on_end(generate_span(), State),
 
     receive
         {'EXIT', Pid, _} ->
@@ -58,31 +59,29 @@ exporting_runner_timeout_test(_Config) ->
 
 check_table_size_test(_Config) ->
     MaxQueueSize = 10,
-    CheckTableSizeMs = 1,
-    {ok, _Pid, #{reg_name := RegName}} = otel_batch_processor:start_link(
-                                           #{name => test_processor_check_size_test,
-                                             resource => otel_resource:create([]),
-                                             exporter => ?MODULE,
-                                             exporting_timeout_ms => timer:minutes(10),
-                                             %% long enough, so that it never happens during the test
-                                             scheduled_delay_ms => timer:minutes(10),
-                                             check_table_size_ms => CheckTableSizeMs,
-                                             max_queue_size => MaxQueueSize}
-                                          ),
+    {ok, _Pid, State} = otel_batch_processor:start_link(
+                          #{name => test_processor_check_size_test,
+                            resource => otel_resource:create([]),
+                            exporter => ?MODULE,
+                            exporting_timeout_ms => timer:minutes(10),
+                            %% long enough, so that it never happens during the test
+                            scheduled_delay_ms => timer:minutes(10),
+                            max_queue_size => MaxQueueSize}
+                         ),
     %% max_queue_size limit is not reached
-    true = otel_batch_processor:on_end(generate_span(), #{reg_name => RegName}),
-    lists:foreach(fun(_) ->
-                          otel_batch_processor:on_end(generate_span(), #{reg_name => RegName})
-                  end,
-                  lists:seq(1, MaxQueueSize)),
-    %% Wait for more than CheckTableSizeMs to be sure check timeout occurred
-    timer:sleep(CheckTableSizeMs * 5),
-    dropped = otel_batch_processor:on_end(generate_span(), #{reg_name => RegName}),
+    true = otel_batch_processor:on_end(generate_span(), State),
 
-    otel_batch_processor:force_flush(#{reg_name => RegName}),
-    %% force_flush is async, have to wait for some long enough time again,
-    timer:sleep(CheckTableSizeMs * 10),
-    true = otel_batch_processor:on_end(generate_span(), #{reg_name => RegName}).
+    insert_spans(State, MaxQueueSize),
+  
+    %% Wait a little to give the handler time to transition to the export state
+    timer:sleep(30),
+
+    %% Insert the same number again, rgis time to the next table, as the previous is being exported,
+    %% exporter is slow (see init_per_testcase), so we can be sure that we will go to the drop mode,
+    %% with no chance to switch the table this time.
+    insert_spans(State, MaxQueueSize),
+
+    dropped = otel_batch_processor:on_end(generate_span(), State).
 
 %% exporter behaviour
 
@@ -96,6 +95,10 @@ shutdown(_) ->
     ok.
 
 %% helpers
+
+insert_spans(State, N) ->
+    lists:foreach(fun(_) -> otel_batch_processor:on_end(generate_span(), State) end,
+                  lists:seq(1, N)).
 
 generate_span() ->
     #span{trace_id = otel_id_generator:generate_trace_id(),

--- a/apps/opentelemetry_api/src/opentelemetry.erl
+++ b/apps/opentelemetry_api/src/opentelemetry.erl
@@ -59,7 +59,8 @@
          status/1,
          status/2,
          verify_and_set_term/3,
-         vsn_to_binary/1]).
+         vsn_to_binary/1,
+         cleanup_persistent_terms/0]).
 
 -include("opentelemetry.hrl").
 -include_lib("kernel/include/logger.hrl").
@@ -444,6 +445,9 @@ status(?OTEL_STATUS_UNSET, _Message) ->
     #status{code=?OTEL_STATUS_UNSET};
 status(_, _) ->
     undefined.
+
+cleanup_persistent_terms() ->
+    otel_utils:cleanup_persistent_terms(?MODULE).
 
 %% internal functions
 

--- a/apps/opentelemetry_api/src/otel_utils.erl
+++ b/apps/opentelemetry_api/src/otel_utils.erl
@@ -22,7 +22,8 @@
          format_binary_string/3,
          assert_to_binary/1,
          unicode_to_binary/1,
-         stack_without_args/1]).
+         stack_without_args/1,
+         cleanup_persistent_terms/1]).
 
 -if(?OTP_RELEASE >= 24).
 format_exception(Kind, Reason, StackTrace) ->
@@ -65,3 +66,14 @@ stack_without_args([StItem | T] ) ->
     [StItem | stack_without_args(T)];
 stack_without_args([]) ->
     [].
+
+-spec cleanup_persistent_terms(module()) -> ok.
+cleanup_persistent_terms(Module) ->
+    lists:foreach(
+      fun({Key, _})  ->
+              case is_tuple(Key) andalso element(1, Key) =:= Module of
+                  true -> persistent_term:erase(Key);
+                  false -> ok
+              end
+      end,
+      persistent_term:get()).

--- a/apps/opentelemetry_api_experimental/src/opentelemetry_experimental.erl
+++ b/apps/opentelemetry_api_experimental/src/opentelemetry_experimental.erl
@@ -25,7 +25,8 @@
          get_meter/0,
          get_meter/1,
          start_default_metrics/0,
-         stop_default_metrics/0]).
+         stop_default_metrics/0,
+         cleanup_persistent_terms/0]).
 
 -include_lib("kernel/include/logger.hrl").
 -include("otel_meter.hrl").
@@ -129,3 +130,6 @@ start_default_metrics() ->
 -spec stop_default_metrics() -> ok | {error, Reason :: atom()}.
 stop_default_metrics() ->
     opentelemetry_experimental_app:stop_default_metrics().
+
+cleanup_persistent_terms() ->
+    otel_utils:cleanup_persistent_terms(?MODULE).

--- a/apps/opentelemetry_experimental/src/opentelemetry_experimental_app.erl
+++ b/apps/opentelemetry_experimental/src/opentelemetry_experimental_app.erl
@@ -26,6 +26,7 @@ start(_StartType, _StartArgs) ->
    {ok, Pid}.
 
 stop(_State) ->
+    _ = opentelemetry_experimental:cleanup_persistent_terms(),
     ok.
 
 -spec start_default_metrics() -> supervisor:startchild_ret().

--- a/apps/opentelemetry_experimental/src/otel_log_handler.erl
+++ b/apps/opentelemetry_experimental/src/otel_log_handler.erl
@@ -17,25 +17,14 @@
 %%%-------------------------------------------------------------------------
 -module(otel_log_handler).
 
--behaviour(gen_statem).
-
 -include_lib("kernel/include/logger.hrl").
-
--export([start_link/1]).
+-include_lib("opentelemetry_api/include/opentelemetry.hrl").
 
 %% Logger handler
 -export([log/2,
          adding_handler/1,
          removing_handler/1,
          changing_config/3]).
-
-%% gen_statem
--export([init/1,
-         callback_mode/0,
-         init_exporter/3,
-         idle/3,
-         exporting/3,
-         terminate/3]).
 
 %% OpenTelemetry specific
 -export([force_flush/1]).
@@ -44,171 +33,93 @@
               otel_log_handler_config/0]).
 
 -type config() :: #{id => logger:handler_id(),
-                    config => otel_log_handler_config(),
                     level => logger:level() | all | none,
                     module => module(),
                     filter_default => log | stop,
                     filters => [{logger:filter_id(), logger:filter()}],
-                    formatter => {module(), logger:formatter_config()}
+                    formatter => {module(), logger:formatter_config()},
+                    config => otel_log_handler_config()
                    }.
 
--type config_private() :: #{id => logger:handler_id(),
-                            level => logger:level() | all | none,
-                            module => module(),
-                            filter_default => log | stop,
-                            filters => [{logger:filter_id(), logger:filter()}],
-                            formatter => {module(), logger:formatter_config()},
-                            config := otel_log_handler_config(),
-                            %% private fields
-                            reg_name := atom(),
-                            atomic_ref := atomics:atomic_ref(),
-                            tables := {ets:table(), ets:table()}
-                           }.
+-type config_state() :: #{id => logger:handler_id(),
+                          level => logger:level() | all | none,
+                          module => module(),
+                          filter_default => log | stop,
+                          filters => [{logger:filter_id(), logger:filter()}],
+                          formatter => {module(), logger:formatter_config()},
+                          config := otel_batch_olp:otel_batch_olp_state()
+                         }.
 
 -type otel_log_handler_config() ::
-        #{max_queue_size => max_queue_size(),
-          exporting_timeout_ms => exporting_timeout_ms(),
-          scheduled_delay_ms => scheduled_delay_ms(),
-          exporter => exporter_config()}.
-
--type max_queue_size() :: non_neg_integer() | infinity.
--type exporter_config() :: module() | {module(), Config :: term()} | undefined.
--type exporting_timeout_ms() :: non_neg_integer().
--type scheduled_delay_ms() :: non_neg_integer().
+        #{max_queue_size => otel_batch_olp:max_queue_size(),
+          exporting_timeout_ms => otel_batch_olp:otel_timeout_ms(),
+          scheduled_delay_ms => otel_batch_olp:otel_timeout_ms(),
+          exporter => otel_exporter:exporter_config()}.
 
 -define(SUP, opentelemetry_experimental_sup).
-
--define(name_to_reg_name(Module, Id),
-        list_to_atom(lists:concat([Module, "_", Id]))).
--define(table_name(_RegName_, _TabName_), list_to_atom(lists:concat([_RegName_, "_", _TabName_]))).
--define(table_1(_RegName_), ?table_name(_RegName_, table1)).
--define(table_2(_RegName_), ?table_name(_RegName_, table2)).
-
-%% Use of atomics provides much better overload protection comparing to periodic ETS table size check.
-%% It allows to enter drop mode as soon as max_queue_size is reached, while periodic table check
-%% can overlook a large and fast burst of writes that can result in inserting a much larger amount of
-%% log events than the configured max_queue_size.
-%% Performance-wise, the cost of `atomics:get/2`, `atomics:sub_get/3` is comparable with
-%% `persistent_term:get/2,3`
--define(current_tab(_AtomicRef_), atomics:get(_AtomicRef_, ?CURRENT_TAB_IX)).
--define(tab_name(_TabIx_, _Tabs_), element(_TabIx_, _Tabs_)).
--define(next_tab(_CurrentTab_), case _CurrentTab_ of
-                                    ?TAB_1_IX -> ?TAB_2_IX;
-                                    ?TAB_2_IX -> ?TAB_1_IX
-                                end).
-
--define(set_current_tab(_AtomicRef_, _TabIx_), atomics:put(_AtomicRef_, ?CURRENT_TAB_IX, _TabIx_)).
--define(set_available(_AtomicRef_, _TabIx_, _Size_), atomics:put(_AtomicRef_, _TabIx_, _Size_)).
--define(get_available(_AtomicRef_, _TabIx_), atomics:get(_AtomicRef_, _TabIx_)).
--define(sub_get_available(_AtomicRef_, _TabIx_), atomics:sub_get(_AtomicRef_, _TabIx_, 1)).
--define(disable(_AtomicRef_), atomics:put(_AtomicRef_, ?CURRENT_TAB_IX, 0)).
-
--define(MAX_SIGNED_INT, (1 bsl 63)-1).
--define(TAB_1_IX, 1).
--define(TAB_2_IX, 2).
-%% signifies which table is currently enabled (0 - disabled, 1 - table_1, 2 - table_2)
--define(CURRENT_TAB_IX, 3).
-
--define(private_field_err(_FieldName_), {error, {_FieldName_, "private_field_change_not_allowed"}}).
--define(change_not_allowed_err(_FieldName_), {error, {_FieldName_, "field_change_not_allowed"}}).
 
 -define(DEFAULT_MAX_QUEUE_SIZE, 2048).
 -define(DEFAULT_SCHEDULED_DELAY_MS, timer:seconds(1)).
 -define(DEFAULT_EXPORTER_TIMEOUT_MS, timer:seconds(30)).
 -define(DEFAULT_EXPORTER_MODULE, opentelemetry_exporter).
--define(DEFAULT_EXPORTER,
-        {?DEFAULT_EXPORTER_MODULE, #{protocol => grpc, endpoints => ["http://localhost:4317"]}}).
+-define(DEFAULT_EXPORTER, {?DEFAULT_EXPORTER_MODULE, #{protocol => grpc}}).
 
+%% Slightly hiher than GRACE_SHUTDOWN_MS, so that the supervisor doesn't kill the handler too early
 -define(SUP_SHUTDOWN_MS, 5500).
-%% Slightly lower than SUP_SHUTDOWN_MS
 -define(GRACE_SHUTDOWN_MS, 5000).
--define(time_ms, erlang:monotonic_time(millisecond)).
--define(rem_time(_Timeout_, _T0_, _T1_), max(0, _Timeout_ - (_T1_ - _T0_))).
-
--record(data, {exporter              :: {module(), State :: term()} | undefined,
-               exporter_config       :: exporter_config(),
-               resource              :: otel_resource:t(),
-               handed_off_table      :: ets:table() | undefined,
-               runner_pid            :: pid() | undefined,
-               tables                :: {ets:table(), ets:table()},
-               reg_name              :: atom(),
-               config                :: config_private(),
-               max_queue_size        = ?DEFAULT_MAX_QUEUE_SIZE        :: non_neg_integer(),
-               exporting_timeout_ms  = ?DEFAULT_EXPORTER_TIMEOUT_MS   :: exporting_timeout_ms(),
-               scheduled_delay_ms    = ?DEFAULT_SCHEDULED_DELAY_MS    :: scheduled_delay_ms(),
-               atomic_ref            :: atomics:atomic_ref(),
-               exporter_timer        :: undefined | reference(),
-               extra                 = [] %% Unused, for future extensions
-              }).
-
-start_link(#{reg_name := RegName} = Config) ->
-    gen_statem:start_link({local, RegName}, ?MODULE, Config, []).
-
-%% TODO:
-%% - implement max_batch_size (it will also require changes in exporter and/or otel_otlp_logs)
 
 %%--------------------------------------------------------------------
 %% Logger handler callbacks
 %%--------------------------------------------------------------------
 
--spec adding_handler(Config1) -> {ok, Config2} | {error, Reason} when
-      Config1 :: config(),
-      Config2 :: config_private(),
-      Reason :: term().
+-spec adding_handler(config()) -> {ok, config_state()} | {error, term()}.
 adding_handler(#{id := Id}=Config) ->
-    ok = start_apps(),
-    RegName = ?name_to_reg_name(?MODULE, Id),
-    AtomicRef = atomics:new(3, [{signed, true}]),
-    Config1 = Config#{reg_name => RegName,
-                      tables => {?table_1(RegName), ?table_2(RegName)},
-                      atomic_ref => AtomicRef},
-    OtelConfig = maps:get(config, Config, #{}),
-    case validate_config(OtelConfig) of
-        ok ->
-            OtelConfig1 = maps:merge(default_config(), OtelConfig),
-            start(Id, Config1#{config => OtelConfig1});
+    %% Don't start opentelemetry_exporter here as it depends on ssl app, which also installs
+    %% its own log handler. If ssl app is not started yet, it will cause a deadlock.
+    %% For now, starting opentelemetry_experimental in `adding_handler/1` cb is safe,
+    %% but if some dependencies like ssl are added to it, it will cause issues.
+    _ = application:ensure_all_started(opentelemetry_experimental),
+
+    HandlerConfig = maps:merge(default_config(), maps:get(config, Config, #{})),
+    RegName = ?REG_NAME(Id),
+    OtelBatchOlpConfig = HandlerConfig#{reg_name => RegName,
+                                        cb_module => ?MODULE,
+                                        otel_signal => logs},
+
+    case otel_batch_olp:init_conf(OtelBatchOlpConfig) of
+        {ok, OlpState} ->
+            %% logger conf must keep all the fields of otel_batch_olp conf,
+            %% as it includes table names, reg_name and atomic ref.
+            Config1 = Config#{config => OlpState},
+            start(Id, OlpState, Config1);
         Err ->
             Err
     end.
 
--spec changing_config(SetOrUpdate, OldConfig, NewConfig) ->
-          {ok, Config} | {error, Reason} when
+-spec changing_config(SetOrUpdate, OldConfigState, NewConfig) ->
+          {ok, NewConfigState} | {error, Reason} when
       SetOrUpdate :: set | update,
-      OldConfig :: config_private(),
+      OldConfigState :: config_state(),
       NewConfig :: config(),
-      Config :: config_private(),
+      NewConfigState :: config_state(),
       Reason :: term().
-changing_config(_, #{reg_name := RegName}, #{reg_name := RegName1}) when RegName =/= RegName1 ->
-    ?private_field_err(reg_name);
-changing_config(_, #{atomic_ref := Ref}, #{atomic_ref := Ref1}) when Ref =/= Ref1 ->
-    ?private_field_err(atomic_ref);
-changing_config(_, #{tables := Tabs}, #{tables := Tabs1}) when Tabs =/= Tabs1 ->
-    ?private_field_err(tables);
-%% Changing timeout or exporter config requires restart/re-initialiazation of exporter,
-%% which is not supported now.  If timeout or exporter needs to be changed,
-%% the handler should be stopped and started with the new config
-changing_config(_, #{config := #{exporter := Exporter}},
-                #{config := #{exporter := Exporter1}}) when Exporter =/= Exporter1 ->
-    ?change_not_allowed_err(exporter);
-changing_config(_, #{config := #{exporting_timeout_ms := T}},
-                #{config := #{exporting_timeout_ms := T1}}) when T =/= T1 ->
-    ?change_not_allowed_err(exporting_timeout_ms);
-changing_config(SetOrUpdate, #{reg_name := RegName, config := OldOtelConfig}, NewConfig) ->
-    NewOtelConfig = maps:get(config, NewConfig, #{}),
-    case validate_config(NewOtelConfig) of
-        ok ->
-            NewOtelConfig1 = case SetOrUpdate of
-                                 update -> maps:merge(OldOtelConfig, NewOtelConfig);
-                                 set -> maps:merge(default_config(), NewOtelConfig)
-                             end,
-            NewConfig1 = NewConfig#{config => NewOtelConfig1, reg_name => RegName},
-            gen_statem:call(RegName, {changing_config, NewConfig1});
+changing_config(SetOrUpdate, #{config := #{reg_name := _} = OlpState}, NewConfig) ->
+    NewOlpConfig = maps:get(config, NewConfig, #{}),
+    Default = case SetOrUpdate of
+                  update -> OlpState;
+                  set -> default_config()
+              end,
+    NewOlpConfig1 = maps:merge(with_changeable_fields(Default), NewOlpConfig),
+    %% NewConfig which is `logger:handler_config()` is already merged with either old config or default,
+    %% depending on `SetOrUpdate` value
+    case otel_batch_olp:change_config(OlpState, NewOlpConfig1, NewConfig) of
+        {ok, NewOlpState} ->
+            {ok, NewConfig#{config => NewOlpState}};
         Err ->
             Err
     end.
 
--spec removing_handler(Config) -> ok | {error, Reason} when
-      Config :: config_private(), Reason :: term().
+-spec removing_handler(config_state()) -> ok | {error, term()}.
 removing_handler(_Config=#{id := Id}) ->
     Res = supervisor:terminate_child(?SUP, Id),
     _ = supervisor:delete_child(?SUP, Id),
@@ -216,174 +127,26 @@ removing_handler(_Config=#{id := Id}) ->
 
 -spec log(LogEvent, Config) -> true | dropped | {error, term()} when
       LogEvent :: logger:log_event(),
-      Config :: config_private().
-log(LogEvent, Config) ->
+      Config :: config_state().
+log(LogEvent, #{config := OlpConfig}) ->
     Ts = case LogEvent of
                 #{meta := #{time := Time}} -> Time;
                 _ -> logger:timestamp()
             end,
-    do_insert(Ts, LogEvent, Config).
+    otel_batch_olp:insert_signal({Ts, LogEvent}, OlpConfig).
 
--spec force_flush(config_private()) -> ok.
-force_flush(#{reg_name := RegName}) ->
-    gen_statem:cast(RegName, force_flush).
-
-%%--------------------------------------------------------------------
-%% gen_statem callbacks
-%%--------------------------------------------------------------------
-
-init(Config) ->
-    #{config := #{exporting_timeout_ms := ExportTimeoutMs} = OtelConfig,
-      atomic_ref := AtomicRef,
-      reg_name := RegName,
-      tables := {Tab1, Tab2}} = Config,
-    process_flag(trap_exit, true),
-    Resource = otel_resource_detector:get_resource(),
-    ExporterConfig = maps:get(exporter, OtelConfig, ?DEFAULT_EXPORTER),
-    ExporterConfig1 = exporter_conf_with_timeout(ExporterConfig, ExportTimeoutMs),
-
-    %% assert table names match
-    Tab1 = ?table_1(RegName),
-    Tab2 = ?table_2(RegName),
-    _Tid1 = new_export_table(Tab1),
-    _Tid2 = new_export_table(Tab2),
-
-    %% This is sligthly increased, to give the exporter runner a chance to  garcefully time-out
-    %% before being killed by the handler.
-    ExportTimeoutMs1 = ExportTimeoutMs + 1000,
-
-    Data = #data{atomic_ref=AtomicRef,
-                 exporter=undefined,
-                 exporter_config=ExporterConfig1,
-                 exporting_timeout_ms=ExportTimeoutMs1,
-                 resource=Resource,
-                 tables={Tab1, Tab2},
-                 reg_name=RegName,
-                 config = Config},
-    %% Also used in change_config API, thus mutable
-    Data1 = add_mutable_config_to_data(Config, Data),
-
-    ?set_current_tab(AtomicRef, ?TAB_1_IX),
-    ?set_available(AtomicRef, ?TAB_1_IX, Data1#data.max_queue_size),
-    ?set_available(AtomicRef, ?TAB_2_IX, Data1#data.max_queue_size),
-
-    {ok, init_exporter, Data1}.
-
-callback_mode() ->
-    [state_functions, state_enter].
-
-%% TODO: handle exporter crashes and re-init it.
-%% This is not expected to happen with the default grpc opentelemetry_exporter,
-%% as it keeps running and retrying by itself in case of network failures.
-init_exporter(enter, _OldState, _Data) ->
-    {keep_state_and_data, [{state_timeout, 0, do_init_exporter}]};
-init_exporter(_, do_init_exporter, Data=#data{exporter_config=ExporterConfig,
-                                              atomic_ref=AtomicRef,
-                                              tables=Tabs,
-                                              scheduled_delay_ms=SendInterval,
-                                              reg_name=RegName}) ->
-    case do_init_exporter(RegName, AtomicRef, Tabs, ExporterConfig) of
-        undefined ->
-            {keep_state_and_data, [{state_timeout, SendInterval, do_init_exporter}]};
-        Exporter ->
-            TimerRef = start_exporting_timer(SendInterval),
-            {next_state, idle, Data#data{exporter=Exporter, exporter_timer=TimerRef}}
-    end;
-init_exporter(_, _, _) ->
-    %% Ignore any other, e.g, external events like force_flush in this state
-    keep_state_and_data.
-
-idle(enter, _OldState, _Data) ->
-    keep_state_and_data;
-idle(info, {timeout, Ref, export_logs}, Data=#data{exporter_timer=Ref}) ->
-    {next_state, exporting, Data};
-idle(cast, force_flush, Data) ->
-    {next_state, exporting, Data};
-idle(EventType, EventContent, Data) ->
-    handle_event_(idle, EventType, EventContent, Data).
-
-exporting(info, {timeout, Ref, export_logs}, #data{exporter_timer=Ref}) ->
-    {keep_state_and_data, [postpone]};
-exporting(enter, _OldState, Data=#data{atomic_ref=AtomicRef,
-                                       tables=Tabs,
-                                       max_queue_size=MaxSize,
-                                       exporting_timeout_ms=ExportingTimeout,
-                                       scheduled_delay_ms=SendInterval}) ->
-    CurrentTab = ?current_tab(AtomicRef),
-    {Data1, Actions} =
-        case ?get_available(AtomicRef, CurrentTab) of
-            %% No events yet, maximum available capacity, nothing to export
-            MaxSize ->
-                %% The other table may contain residual (late) writes not exported
-                %% during the previous run. If current table is not empty, we don't
-                %% need to check the size of the previous (currently disabled) table,
-                %% since we will switch to it after this exporter run.
-                %% However, if current table remains empty for a long time,
-                %% neither export nor table switch will be triggered, and any
-                %% residual late log events in the previous table would be left
-                %% dangling. To avoid such cases, we check other table size
-                %% and export it if it's not empty.
-                maybe_export_other_table(CurrentTab, Data);
-            _ ->
-                RunnerPid = export_logs(CurrentTab, Data),
-                {Data#data{runner_pid=RunnerPid,
-                           handed_off_table=?tab_name(CurrentTab, Tabs)},
-                 [{state_timeout, ExportingTimeout, exporting_timeout}]}
-        end,
-    {keep_state, Data1#data{exporter_timer = start_exporting_timer(SendInterval)}, Actions};
-exporting(state_timeout, empty_table, Data) ->
-    {next_state, idle, Data};
-exporting(state_timeout, exporting_timeout, Data) ->
-    %% kill current exporting process because it is taking too long
-    Data1 = kill_runner(Data),
-    {next_state, idle, Data1};
-%% important to verify runner_pid and FromPid are the same in case it was sent
-%% after kill_runner was called but before it had done the unlink
-%% Exit reason is ignored, since we don't handle exporter failures specifically for now
-exporting(info, {'EXIT', FromPid, _}, Data=#data{runner_pid=FromPid}) ->
-    complete_exporting(Data);
-exporting(EventType, Event, Data) ->
-    handle_event_(exporting, EventType, Event, Data).
-
-terminate(_Reason, State, Data=#data{exporter=Exporter,
-                                     resource=Resource,
-                                     config=Config,
-                                     atomic_ref=AtomicRef,
-                                     tables={Tab1, Tab2}
-                                    }) ->
-    ?disable(AtomicRef),
-    T0 = ?time_ms,
-    _ = maybe_wait_for_current_runner(State, Data, ?GRACE_SHUTDOWN_MS),
-    T1 = ?time_ms,
-
-    %% Check both tables as each one may have some late unexported log events.
-    %% NOTE: exports are attempted sequentially to follow the specification restriction:
-    %% "Export will never be called concurrently for the same exporter instance"
-    %% (see: https://opentelemetry.io/docs/specs/otel/logs/sdk/#export).
-    RemTime = ?rem_time(?GRACE_SHUTDOWN_MS, T0, T1),
-    ets:info(Tab1, size) > 0
-        andalso export_and_wait(Exporter, Resource, Tab1, Config, RemTime),
-    T2 = ?time_ms,
-    RemTime1 = ?rem_time(RemTime, T1, T2),
-    ets:info(Tab2, size) > 0
-        andalso export_and_wait(Exporter, Resource, Tab2, Config, RemTime1),
-
-    _ = otel_exporter:shutdown(Exporter),
-    ok.
+-spec force_flush(config_state()) -> ok.
+force_flush(#{config := OlpConfig}) ->
+    otel_batch_olp:force_flush(OlpConfig).
 
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
 
-start_apps() ->
-    _ = application:ensure_all_started(opentelemetry_exporter),
-    _ = application:ensure_all_started(opentelemetry_experimental),
-    ok.
-
-start(Id, Config) ->
+start(Id, OtelBatchOlpState, Config) ->
     ChildSpec =
         #{id       => Id,
-          start    => {?MODULE, start_link, [Config]},
+          start    => {otel_batch_olp, start_link, [OtelBatchOlpState, Config]},
           %% The handler must be stopped gracefully by calling `logger:remove_handler/1`,
           %% which calls `supervisor:terminate_child/2` (in `removing_handler/2` cb).
           %% Any other termination is abnormal and deserves a restart.
@@ -400,219 +163,13 @@ start(Id, Config) ->
             Error
     end.
 
-handle_event_(_State, {call, From}, {changing_config, NewConfig}, Data) ->
-    {keep_state, add_mutable_config_to_data(NewConfig, Data), [{reply, From, {ok, NewConfig}}]};
-handle_event_(_State, info, {'EXIT', Pid, Reason}, #data{runner_pid=RunnerPid})
-  when Pid =/= RunnerPid ->
-    %% This can be a linked exporter process, unless someone linked to the handler process,
-    %% or explicitly called exit(HandlerPid, Reason)
-    %% This will call terminate/3 and may try to export current log events,
-    %% even if the linked exporter process is down.
-    %% This is safe, though, as all errors of otel_exporter:export_logs/4 are caught.
-    {stop, Reason};
-handle_event_(_State, _, _, _) ->
-    keep_state_and_data.
-
-do_init_exporter(RegName, AtomicRef, Tabs, ExporterConfig) ->
-    case otel_exporter:init(logs, RegName, ExporterConfig) of
-        Exporter when Exporter =/= undefined andalso Exporter =/= none ->
-            %% Need to enable log writes, if it has been disabled previously
-            ?set_current_tab(AtomicRef, ?TAB_1_IX),
-            Exporter;
-        _ ->
-            %% exporter is undefined/none
-            %% disable the insertion of new log events and delete the current table
-            clear_table_and_disable(AtomicRef, Tabs),
-            undefined
-    end.
-
-start_exporting_timer(SendInterval) ->
-    erlang:start_timer(SendInterval, self(), export_logs).
-
-maybe_export_other_table(CurrentTab, Data=#data{tables=Tabs,
-                                                exporting_timeout_ms=ExportingTimeout}) ->
-    NextTab = ?next_tab(CurrentTab),
-    %% Check ETS size instead of the counter, as late writes can't be detected with the atomic counter
-    case ets:info(?tab_name(NextTab, Tabs), size) of
-        0 ->
-            %% in an `enter' handler we can't return a `next_state' or `next_event'
-            %% so we rely on a timeout to trigger the transition to `idle'
-            {Data#data{runner_pid=undefined}, [{state_timeout, 0, empty_table}]};
-        _ ->
-            RunnerPid = export_logs(NextTab, Data),
-            {Data#data{runner_pid=RunnerPid, handed_off_table=?tab_name(CurrentTab, Tabs)},
-             [{state_timeout, ExportingTimeout, exporting_timeout}]}
-    end.
-
-export_logs(CurrentTab, #data{exporter=Exporter,
-                              max_queue_size=MaxSize,
-                              resource=Resource,
-                              atomic_ref=AtomicRef,
-                              tables=Tabs,
-                              config=Config}) ->
-
-    NewCurrentTab = ?next_tab(CurrentTab),
-    %% the new table is expected to be empty or hold a few late writes from the previous export,
-    %% so it safe to set available max size
-    ?set_available(AtomicRef, NewCurrentTab, MaxSize),
-    ?set_current_tab(AtomicRef, NewCurrentTab),
-    export_async(Exporter, Resource, ?tab_name(CurrentTab, Tabs), Config).
-
-export_async(Exporter, Resource, CurrentTab, Config) ->
-    erlang:spawn_link(fun() -> export(Exporter, Resource, CurrentTab, Config) end).
-
-export(undefined, _, _, _) ->
-    true;
-export({ExporterModule, ExporterState}, Resource, Tab, Config) ->
-    try
-        %% we ignore values, as no retries mechanism, is implemented
-        otel_exporter:export_logs(ExporterModule, {Tab, Config}, Resource, ExporterState)
-    catch
-        Class:Reason:St ->
-            %% Other logger handler(s) (e.g. default) should be enabled, so that
-            %% log events produced by otel_log_handler are not lost in case otel_log_handler
-            %% is not functioning properly.
-            ?LOG_ERROR("logs exporter ~p failed with exception: ~p:~p, stacktrace: ~p",
-                       [Class, Reason, otel_utils:stack_without_args(St)]),
-            error
-    end.
-
-new_export_table(Name) ->
-    %% log event timestamps used as keys are not guaranteed to always be unique,
-    %% so we use duplicate_bag
-    %% Using timestamps as keys instead of instrumentation scopes is expected
-    %% to have higher entropy which should improve write concurrency
-    ets:new(Name, [public,
-                   named_table,
-                   {write_concurrency, true},
-                   duplicate_bag]).
-
-do_insert(Ts, LogEvent, #{atomic_ref := AtomicRef, tables := Tabs} = Config) ->
-    try
-        case ?current_tab(AtomicRef) of
-            0 -> dropped;
-            CurrentTab ->
-                case ?sub_get_available(AtomicRef, CurrentTab) of
-                    Seq when Seq > 0 ->
-                        ets:insert(?tab_name(CurrentTab, Tabs), {Ts, LogEvent});
-                    0 ->
-                        %% max_queue_size is reached
-                        Res = ets:insert(?tab_name(CurrentTab, Tabs), {Ts, LogEvent}),
-                        _ = force_flush(Config),
-                        Res;
-                    _ ->
-                        dropped
-                end
-        end
-    catch
-        error:badarg ->
-            {error, no_otel_log_handler};
-        Err:Reason ->
-            {error, {Err, Reason}}
-    end.
-
-clear_table_and_disable(AtomicRef, Tabs) ->
-    case ?current_tab(AtomicRef) of
-        0 ->
-            %% already disabled
-            ok;
-        CurrentTab ->
-            ?disable(AtomicRef),
-            CurrentTabName = ?tab_name(CurrentTab, Tabs),
-            ets:delete_all_objects(CurrentTabName),
-            ok
-    end.
-
-complete_exporting(Data) ->
-    {next_state, idle, Data#data{runner_pid=undefined,
-                                 handed_off_table=undefined}}.
-
-kill_runner(Data=#data{runner_pid=RunnerPid, handed_off_table=Tab}) when RunnerPid =/= undefined ->
-    Mon = erlang:monitor(process, RunnerPid),
-    erlang:unlink(RunnerPid),
-    erlang:exit(RunnerPid, kill),
-    %% NOTE: this is not absolutely necessary anymore, as we don't delete/recreate tables
-    receive
-        {'DOWN', Mon, process, RunnerPid, _} ->
-            %% NOTE: if the runner was killed even before it managed to take all or
-            %% at least significant amount of records from the table and
-            %% exporter timeouts keep occurring on and on, there is a risk of continuous
-            %% table size growth. This situation has a low probability,
-            %% especially when the configuration is meaningful, e.g., max_queue_size is not
-            %% enormously large and exporting_timeout is not very small.
-            %% The table is cleared as a safety measure to eliminate the risk of the above case.
-            %% This should probably be optional and configurable.
-            _ = ets:delete_all_objects(Tab),
-            Data#data{runner_pid=undefined, handed_off_table=undefined}
-    end.
-
-exporter_conf_with_timeout({?DEFAULT_EXPORTER_MODULE, Conf}, TimeoutMs) ->
-    {?DEFAULT_EXPORTER_MODULE, Conf#{timeout_ms => TimeoutMs}};
-exporter_conf_with_timeout(OtherExporter, _Timeout) ->
-    OtherExporter.
-
-%% terminate/3 helpers
-
-export_and_wait(Exporter, Resource, Tab, Config, Timeout) ->
-    RunnerPid = export_async(Exporter, Resource, Tab, Config),
-    wait_for_runner(RunnerPid, Timeout).
-
-wait_for_runner(RunnerPid, Timeout) ->
-    receive
-        {'EXIT', RunnerPid, _} -> ok
-    after Timeout ->
-            erlang:exit(RunnerPid, kill),
-            ok
-    end.
-
-maybe_wait_for_current_runner(exporting, #data{runner_pid=RunnerPid}, Timeout) when is_pid(RunnerPid) ->
-    wait_for_runner(RunnerPid, Timeout);
-maybe_wait_for_current_runner(_State, _Date, _Timeout) -> ok.
-
-%% Config helpers
-
 default_config() ->
-    %% exporter is set separately because it's not allowed to be changed for now (requires handler restart)
     #{max_queue_size => ?DEFAULT_MAX_QUEUE_SIZE,
       exporting_timeout_ms => ?DEFAULT_EXPORTER_TIMEOUT_MS,
-      scheduled_delay_ms => ?DEFAULT_SCHEDULED_DELAY_MS}.
+      scheduled_delay_ms => ?DEFAULT_SCHEDULED_DELAY_MS,
+      shutdown_timeout_ms => ?GRACE_SHUTDOWN_MS,
+      exporter => ?DEFAULT_EXPORTER}.
 
-validate_config(Config) ->
-    Errs = maps:fold(fun(K, Val, Acc) ->
-                             case validate_opt(K, Val, Config) of
-                                 ok -> Acc;
-                                 Err -> [Err | Acc]
-                             end
-              end,
-                     [], Config),
-    case Errs of
-        [] -> ok;
-        _ -> {error, Errs}
-    end.
-
-validate_opt(max_queue_size, infinity, _Config) ->
-    ok;
-validate_opt(K, Val, _Config) when is_integer(Val), Val > 0,
-                          K =:= max_queue_size;
-                          K =:= exporting_timeout_ms;
-                          K =:= scheduled_delay_ms->
-    ok;
-validate_opt(exporter, {Module, _}, _Config) when is_atom(Module) ->
-    ok;
-validate_opt(exporter, Module, _Config) when is_atom(Module) ->
-    ok;
-validate_opt(K, Val, _Config) ->
-    {invalid_config, K, Val}.
-
-add_mutable_config_to_data(#{config := OtelConfig} = Config, Data) ->
-    #{max_queue_size:=SizeLimit,
-      scheduled_delay_ms:=ScheduledDelay
-     } = OtelConfig,
-    SizeLimit1 = case SizeLimit of
-                     %% high enough, must be infeasible to reach
-                     infinity -> ?MAX_SIGNED_INT;
-                     Int  -> Int
-                 end,
-    Data#data{config=Config,
-              max_queue_size=SizeLimit1,
-              scheduled_delay_ms=ScheduledDelay}.
+%% Select fields that are allowed to be changed
+with_changeable_fields(Config) ->
+    maps:with([max_queue_size, scheduled_delay_ms], Config).

--- a/apps/opentelemetry_experimental/src/otel_metric_reader.erl
+++ b/apps/opentelemetry_experimental/src/otel_metric_reader.erl
@@ -46,7 +46,7 @@
         {
          exporter,
          provider_sup :: supervisor:sup_ref(),
-         id :: reference(),
+         id :: atom(),
          default_aggregation_mapping :: #{otel_instrument:kind() => module()},
          temporality_mapping :: #{otel_instrument:kind() => otel_instrument:temporality()},
          export_interval_ms :: integer() | undefined,
@@ -174,7 +174,7 @@ code_change(State) ->
 
 %%
 
--spec collect_(any(), ets:table(), any(), reference()) -> [any()].
+-spec collect_(any(), ets:table(), any(), atom()) -> [any()].
 collect_(CallbacksTab, ViewAggregationTab, MetricsTab, ReaderId) ->
     _ = run_callbacks(ReaderId, CallbacksTab, ViewAggregationTab, MetricsTab),
 

--- a/apps/opentelemetry_experimental/src/otel_observables.erl
+++ b/apps/opentelemetry_experimental/src/otel_observables.erl
@@ -27,7 +27,7 @@
 -type callbacks() :: [{otel_instrument:callback(), otel_instrument:callback_args(), otel_instrument:t()}].
 
 %% call each callback and associate the result with the Instruments it observes
--spec run_callbacks(callbacks(), reference(), ets:table(), ets:table()) -> ok.
+-spec run_callbacks(callbacks(), atom(), ets:table(), ets:table()) -> ok.
 run_callbacks(Callbacks, ReaderId, ViewAggregationTab, MetricsTab) ->
     lists:foreach(fun({Callback, CallbackArgs, Instruments})
                         when is_list(Instruments) ->
@@ -49,7 +49,7 @@ run_callbacks(Callbacks, ReaderId, ViewAggregationTab, MetricsTab) ->
 
 %% lookup ViewAggregations for Instrument and aggregate each observation
 -spec handle_instrument_observations([otel_instrument:observation()], otel_instrument:t(),
-                                     ets:table(), ets:table(), reference()) -> ok.
+                                     ets:table(), ets:table(), atom()) -> ok.
 handle_instrument_observations(Results, #instrument{meter=Meter,
                                                     name=Name},
                                ViewAggregationTab, MetricsTab, ReaderId) ->
@@ -67,7 +67,7 @@ handle_instrument_observations(Results, #instrument{meter=Meter,
 
 %% handle results for a multi-instrument callback
 -spec handle_instruments_observations([otel_instrument:named_observations()], [otel_instrument:t()],
-                                      ets:table(), ets:table(), reference()) -> ok.
+                                      ets:table(), ets:table(), atom()) -> ok.
 handle_instruments_observations([], _Instruments, _ViewAggregationTab, _MetricsTab, _ReaderId) ->
     ok;
 handle_instruments_observations([{InstrumentName, Results} | Rest], Instruments,

--- a/apps/opentelemetry_exporter/src/otel_otlp_traces.erl
+++ b/apps/opentelemetry_exporter/src/otel_otlp_traces.erl
@@ -48,22 +48,43 @@ to_proto(Tab, Resource) ->
     end.
 
 to_proto_by_instrumentation_scope(Tab) ->
-    Key = ets:first(Tab),
-    to_proto_by_instrumentation_scope(Tab, Key).
+    %% Even though during the export log events are being inserted to another table,
+    %% some late writes to the table being exported are still possible.
+    %% Thus, we can't lookup all the log events from the table and then let otel_log_handler
+    %% delete the table completely and re-create it as it will imply the risk of losing those (possible) late writes.
+    %% So, we fix the table and traverse it with ets:take/2. After that, the late writes won't be exported,
+    %% but they will be kept in the table and ready to be exported in the next exporter runs.
+    true = ets:safe_fixtable(Tab, true),
+    try
+        to_proto_by_instrumentation_scope(Tab, ets:first(Tab), #{})
+    after
+        _ = ets:safe_fixtable(Tab, false)
+    end.
 
-to_proto_by_instrumentation_scope(_Tab, '$end_of_table') ->
-    [];
-to_proto_by_instrumentation_scope(Tab, InstrumentationScope) ->
-    InstrumentationScopeSpans = lists:foldl(fun(Span, Acc) ->
-                                                      [to_proto(Span) | Acc]
-                                              end, [], ets:lookup(Tab, InstrumentationScope)),
-    InstrumentationScopeSpansProto = otel_otlp_common:to_instrumentation_scope_proto(InstrumentationScope),
-    [InstrumentationScopeSpansProto#{spans => InstrumentationScopeSpans}
-    | to_proto_by_instrumentation_scope(Tab, ets:next(Tab, InstrumentationScope))].
+to_proto_by_instrumentation_scope(_Tab, '$end_of_table', ScopeAcc) ->
+    maps:fold(
+      fun(Scope, Spans, Acc) ->
+              ScopeProto = otel_otlp_common:to_instrumentation_scope_proto(Scope),
+              [ScopeProto#{spans => Spans} | Acc]
+      end,
+      [],
+      ScopeAcc);
+to_proto_by_instrumentation_scope(Tab, Key, ScopeAcc) ->
+    ScopeAcc1 = lists:foldl(
+                  fun(#span{instrumentation_scope=Scope}=Span, Acc) ->
+                          SpanProto = to_proto(Span),
+                          maps:update_with(Scope,
+                                           fun(Spans) -> [SpanProto | Spans] end,
+                                           [SpanProto],
+                                           Acc)
+                  end,
+                  ScopeAcc,
+                  ets:take(Tab, Key)),
+    Key1 = ets:next(Tab, Key),
+    to_proto_by_instrumentation_scope(Tab, Key1, ScopeAcc1).
 
 %% TODO: figure out why this type spec fails
 %% -spec to_proto(#span{}) -> opentelemetry_exporter_trace_service_pb:span().
-
 to_proto(#span{trace_id=TraceId,
                span_id=SpanId,
                tracestate=TraceState,


### PR DESCRIPTION
- moved common functionality implemented in `otel_log_handler` to a common module: `otel_batch_olp`
- re-worked `otel_batch_processor` (traces) to use the new module
- some fixes/improvements:
    - disable `otel_batch_olp` if exporter explicitly returns `ignore`
    - fix tests and type specs
    - cleanup persistent terms when applications are stopped