### PR TITLE
Default tracer start stop api

### DIFF
--- a/apps/opentelemetry/src/opentelemetry_app.erl
+++ b/apps/opentelemetry/src/opentelemetry_app.erl
@@ -28,46 +28,11 @@ start(_StartType, _StartArgs) ->
     Config = otel_configuration:merge_with_os(
                application:get_all_env(opentelemetry)),
 
-    %% set the global propagators for HTTP based on the application env
-    %% these get set even if the SDK is disabled
-    setup_text_map_propagators(Config),
-
     SupResult = opentelemetry_sup:start_link(Config),
-
-    case Config of
-        #{sdk_disabled := true} ->
-            %% skip the rest if the SDK is disabled
-            SupResult;
-        _ ->
-            %% set global span limits record based on configuration
-            otel_span_limits:set(Config),
-
-            Resource = otel_resource_detector:get_resource(),
-            _ = otel_tracer_provider_sup:start(?GLOBAL_TRACER_PROVIDER_NAME, Resource, Config),
-
-            %% must be done after the supervisor starts so that otel_tracer_server is running
-            %% TODO: make this work with release upgrades. Currently if an application's version
-            %% changes the version in the tracer will not be updated.
-            create_loaded_application_tracers(Config),
-
-            SupResult
-    end.
+    _ = opentelemetry:start_default_tracer_provider(),
+    SupResult.
 
 stop(_State) ->
     _ = opentelemetry:cleanup_persistent_terms(),
     _ = otel_span_limits:cleanup_persistent_terms(),
-    ok.
-
-%% internal functions
-
-setup_text_map_propagators(#{text_map_propagators := List}) ->
-    CompositePropagator = otel_propagator_text_map_composite:create(List),
-    opentelemetry:set_text_map_propagator(CompositePropagator).
-
-create_loaded_application_tracers(#{create_application_tracers := true}) ->
-    %% TODO: filter out OTP apps that will not have any instrumentation
-    LoadedApplications = application:loaded_applications(),
-    opentelemetry:create_application_tracers(LoadedApplications),
-    ok;
-create_loaded_application_tracers(_) ->
     ok.

--- a/apps/opentelemetry_api_experimental/src/opentelemetry_experimental.erl
+++ b/apps/opentelemetry_api_experimental/src/opentelemetry_experimental.erl
@@ -129,7 +129,9 @@ start_default_metrics() ->
 
 -spec stop_default_metrics() -> ok | {error, Reason :: atom()}.
 stop_default_metrics() ->
-    opentelemetry_experimental_app:stop_default_metrics().
+    SupRes = opentelemetry_experimental_app:stop_default_metrics(),
+    _ = cleanup_persistent_terms(),
+    SupRes.
 
 cleanup_persistent_terms() ->
     otel_utils:cleanup_persistent_terms(?MODULE).


### PR DESCRIPTION
Similarly to https://github.com/emqx/opentelemetry-erlang/pull/6

Need more fine-grained control over the lib default tracer to easily stop/start traces, logs and metrics in response to configuration changes. 