### PR TITLE
chore(mix): resolve compiler warnings

### DIFF
--- a/apps/opentelemetry_api/mix.exs
+++ b/apps/opentelemetry_api/mix.exs
@@ -50,7 +50,7 @@ defmodule OpenTelemetry.MixProject do
   end
 
   defp load_app do
-    {:ok, [{:application, name, desc}]} = :file.consult('src/opentelemetry_api.app.src')
+    {:ok, [{:application, name, desc}]} = :file.consult(~c"src/opentelemetry_api.app.src")
 
     {name, desc}
   end

--- a/apps/opentelemetry_api_experimental/mix.exs
+++ b/apps/opentelemetry_api_experimental/mix.exs
@@ -82,14 +82,14 @@ defmodule OpenTelemetryExperimental.MixProject do
   end
 
   defp load_config do
-    {:ok, config} = :file.consult('rebar.config')
+    {:ok, config} = :file.consult(~c"rebar.config")
 
     config
   end
 
   defp load_app do
     {:ok, [{:application, name, desc}]} =
-      :file.consult('src/opentelemetry_api_experimental.app.src')
+      :file.consult(~c"src/opentelemetry_api_experimental.app.src")
 
     {name, desc}
   end


### PR DESCRIPTION
Recent enough Elixir raises following deprecation warnings. This PR attempts to fix them.
```
warning: using single-quoted strings to represent charlists is deprecated.
```
