### PR TITLE
fix(api): cap W3C Baggage extract at 8192 bytes and 180 entries

### DIFF
--- a/apps/opentelemetry_api/src/otel_propagator_baggage.erl
+++ b/apps/opentelemetry_api/src/otel_propagator_baggage.erl
@@ -50,6 +50,13 @@
 
 -define(BAGGAGE_HEADER, <<"baggage">>).
 
+%% Limits recommended by the W3C Baggage specification and applied by the
+%% other OpenTelemetry SDK implementations (Java SDK 1.62.0
+%% `W3CBaggagePropagator`, Go `propagation/baggage.go`, .NET
+%% `BaggagePropagator.cs`, C++ `baggage.h`).
+-define(MAX_BAGGAGE_BYTES, 8192).
+-define(MAX_BAGGAGE_ENTRIES, 180).
+
 fields(_) ->
     [?BAGGAGE_HEADER].
 
@@ -80,14 +87,69 @@ extract(Ctx, Carrier, _CarrierKeysFun, CarrierGet, _Options) ->
         undefined ->
             Ctx;
         String ->
-            Pairs = string:lexemes(String, [$,]),
-            DecodedBaggage =
-                lists:foldl(fun(Pair, Acc) ->
-                                    [Key, Value] = string:split(Pair, "="),
-                                    Acc#{decode_key(Key) => decode_value(Value)}
+            extract_baggage(String, Ctx)
+    end.
 
-                            end, #{}, Pairs),
-            otel_baggage:set_to(Ctx, DecodedBaggage)
+%% A binary or list header is attacker-controlled content, so extraction must
+%% never crash on it: oversized headers, lists that aren't valid iolists, and
+%% content `string:lexemes/2' rejects are all treated as "missing" and ignored
+%% while the byte cap is enforced. A carrier value that isn't a binary or list
+%% violates the TextMap carrier contract and is rejected loudly instead.
+extract_baggage(String, Ctx) when is_binary(String); is_list(String) ->
+    case header_size(String) of
+        missing ->
+            Ctx;
+        Size when Size > ?MAX_BAGGAGE_BYTES ->
+            Ctx;
+        _ ->
+            case safe_lexemes(String) of
+                Pairs when is_list(Pairs) ->
+                    otel_baggage:set_to(Ctx, decode_pairs(Pairs, #{}, 0));
+                _ ->
+                    Ctx
+            end
+    end;
+extract_baggage(Other, _Ctx) ->
+    error({invalid_baggage_header, Other}).
+
+header_size(String) when is_binary(String) ->
+    byte_size(String);
+header_size(String) when is_list(String) ->
+    try iolist_size(String) of
+        Size -> Size
+    catch
+        error:badarg -> missing
+    end.
+
+%% `string:lexemes/2' raises (badarg on invalid UTF-8, function_clause on
+%% non-chardata) instead of returning an error tuple, so wrap it: content the
+%% propagator can't tokenize is treated as "missing" rather than crashing.
+safe_lexemes(String) ->
+    try string:lexemes(String, [$,])
+    catch
+        error:_ -> missing
+    end.
+
+decode_pairs([], Acc, _N) ->
+    Acc;
+decode_pairs(_Pairs, Acc, N) when N >= ?MAX_BAGGAGE_ENTRIES ->
+    Acc;
+decode_pairs([Pair | Rest], Acc, N) ->
+    case string:split(Pair, "=") of
+        [Key, Value] ->
+            %% `decode_key/1' and `decode_value/1' throw on invalid percent
+            %% encoding, so a single malformed pair must not abort extraction
+            %% of the whole header. Decode the pair in isolation and skip it
+            %% on any failure, like a pair with no `='.
+            try {decode_key(Key), decode_value(Value)} of
+                {DecodedKey, DecodedValue} ->
+                    decode_pairs(Rest, Acc#{DecodedKey => DecodedValue}, N + 1)
+            catch
+                _:_ ->
+                    decode_pairs(Rest, Acc, N + 1)
+            end;
+        _ ->
+            decode_pairs(Rest, Acc, N + 1)
     end.
 
 %%
@@ -115,9 +177,20 @@ decode_key(Key) ->
     percent_decode(string:trim(otel_utils:assert_to_binary(Key))).
 
 decode_value(ValueAndMetadata) ->
-    [Value | MetadataList] = string:lexemes(ValueAndMetadata, [$;]),
+    %% `string:split/3' with `all' preserves empty segments, unlike
+    %% `string:lexemes/2' which drops them. An empty value (`k=') is valid by
+    %% the W3C grammar (`value = *baggage-octet') and must decode to an empty
+    %% value rather than crashing the `[Value | _] = []' match, and a leading
+    %% `;' (`k=;p') must keep that empty value instead of misparsing `p' as
+    %% it. The first segment is always the value; the rest are metadata.
+    [Value | MetadataList] = string:split(ValueAndMetadata, ";", all),
     {string_decode(Value), lists:filtermap(fun metadata_decode/1, MetadataList)}.
 
+metadata_decode(<<>>) ->
+    %% an empty segment (consecutive or trailing `;') is not a property
+    false;
+metadata_decode([]) ->
+    false;
 metadata_decode(Metadata) ->
     case string:split(Metadata, "=") of
         [MetadataKey] ->

--- a/apps/opentelemetry_api/test/otel_propagator_baggage_SUITE.erl
+++ b/apps/opentelemetry_api/test/otel_propagator_baggage_SUITE.erl
@@ -1,0 +1,181 @@
+-module(otel_propagator_baggage_SUITE).
+
+-compile(export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-include("opentelemetry.hrl").
+
+-define(BAGGAGE_HEADER, <<"baggage">>).
+-define(MAX_BAGGAGE_BYTES, 8192).
+-define(MAX_BAGGAGE_ENTRIES, 180).
+
+all() ->
+    [extract_simple,
+     extract_drops_oversized_header,
+     extract_caps_entry_count,
+     extract_within_caps,
+     extract_skips_malformed_pair,
+     extract_skips_undecodable_pair,
+     extract_preserves_empty_value,
+     extract_missing_header,
+     extract_ignores_invalid_iolist,
+     extract_ignores_undecodable_binary,
+     extract_rejects_non_string_value].
+
+init_per_suite(Config) ->
+    application:load(opentelemetry_api),
+    Config.
+
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_TC, Config) ->
+    otel_ctx:clear(),
+    Config.
+
+end_per_testcase(_TC, _Config) ->
+    otel_ctx:clear(),
+    ok.
+
+extract_simple(_Config) ->
+    Header = <<"k1=v1,k2=v2">>,
+    Ctx = extract(Header),
+    Baggage = otel_baggage:get_all(Ctx),
+    ?assertEqual(2, maps:size(Baggage)),
+    ?assertEqual({<<"v1">>, []}, maps:get(<<"k1">>, Baggage)),
+    ?assertEqual({<<"v2">>, []}, maps:get(<<"k2">>, Baggage)),
+    ok.
+
+extract_drops_oversized_header(_Config) ->
+    Header = build_header(2000),
+    ?assert(byte_size(Header) > ?MAX_BAGGAGE_BYTES),
+    Ctx = extract(Header),
+    ?assertEqual(#{}, otel_baggage:get_all(Ctx)),
+    ok.
+
+extract_caps_entry_count(_Config) ->
+    %% Build a header that stays under the byte cap but carries more entries
+    %% than `?MAX_BAGGAGE_ENTRIES`. Short keys/values keep each pair small
+    %% enough that 300 entries are well under 8 KiB.
+    Header = build_short_header(300),
+    ?assert(byte_size(Header) =< ?MAX_BAGGAGE_BYTES),
+    Ctx = extract(Header),
+    Baggage = otel_baggage:get_all(Ctx),
+    ?assertEqual(?MAX_BAGGAGE_ENTRIES, maps:size(Baggage)),
+    ok.
+
+extract_within_caps(_Config) ->
+    Header = build_short_header(50),
+    Ctx = extract(Header),
+    Baggage = otel_baggage:get_all(Ctx),
+    ?assertEqual(50, maps:size(Baggage)),
+    ok.
+
+extract_skips_malformed_pair(_Config) ->
+    Header = <<"k1=v1,malformed,k2=v2">>,
+    Ctx = extract(Header),
+    Baggage = otel_baggage:get_all(Ctx),
+    ?assertEqual(2, maps:size(Baggage)),
+    ?assertEqual({<<"v1">>, []}, maps:get(<<"k1">>, Baggage)),
+    ?assertEqual({<<"v2">>, []}, maps:get(<<"k2">>, Baggage)),
+    ok.
+
+extract_skips_undecodable_pair(_Config) ->
+    %% `decode_key/1' and `decode_value/1' throw on invalid percent encoding
+    %% (`%ZZ'); such a pair is attacker-controlled content and is skipped like
+    %% one with no `=', without aborting extraction or dropping valid entries.
+    BadBetweenGood =
+        [<<"k1=v1,k=%ZZ,k2=v2">>,      %% bad percent encoding in a value
+         <<"k1=v1,%ZZ=v,k2=v2">>,      %% bad percent encoding in a key
+         <<"k1=v1,k=v;%ZZ,k2=v2">>],   %% bad percent encoding in metadata
+    [begin
+         Ctx = extract(Header),
+         Baggage = otel_baggage:get_all(Ctx),
+         ?assertEqual(2, maps:size(Baggage)),
+         ?assertEqual({<<"v1">>, []}, maps:get(<<"k1">>, Baggage)),
+         ?assertEqual({<<"v2">>, []}, maps:get(<<"k2">>, Baggage))
+     end || Header <- BadBetweenGood],
+
+    %% A header that is nothing but an undecodable pair yields no baggage
+    %% rather than crashing.
+    [?assertEqual(#{}, otel_baggage:get_all(extract(Header)))
+     || Header <- [<<"k=%ZZ">>, <<"%ZZ=v">>, <<"k=v;%ZZ">>]],
+    ok.
+
+extract_preserves_empty_value(_Config) ->
+    %% An empty value is valid by the W3C grammar (`value = *baggage-octet'),
+    %% so `k=' must extract an empty value rather than being dropped, and a
+    %% leading `;' (`k=;p') must keep that empty value instead of misparsing
+    %% `p' as it -- the old `string:lexemes/2' split dropped empty segments.
+    ?assertEqual(#{<<"k">> => {<<>>, []}},
+                 otel_baggage:get_all(extract(<<"k=">>))),
+    ?assertEqual(#{<<"k">> => {<<>>, [<<"p">>]}},
+                 otel_baggage:get_all(extract(<<"k=;p">>))),
+
+    %% an empty value keeps its valid neighbors
+    Baggage = otel_baggage:get_all(extract(<<"k1=v1,k=,k2=v2">>)),
+    ?assertEqual(3, maps:size(Baggage)),
+    ?assertEqual({<<"v1">>, []}, maps:get(<<"k1">>, Baggage)),
+    ?assertEqual({<<>>, []}, maps:get(<<"k">>, Baggage)),
+    ?assertEqual({<<"v2">>, []}, maps:get(<<"k2">>, Baggage)),
+
+    %% consecutive/trailing `;' carry no empty property
+    ?assertEqual({<<"v">>, []},
+                 maps:get(<<"k">>, otel_baggage:get_all(extract(<<"k=v;">>)))),
+    ?assertEqual({<<"v">>, [<<"p">>]},
+                 maps:get(<<"k">>, otel_baggage:get_all(extract(<<"k=v;;p">>)))),
+    ok.
+
+extract_missing_header(_Config) ->
+    Ctx0 = otel_ctx:new(),
+    Ctx1 = otel_propagator_baggage:extract(Ctx0, #{},
+                                           fun(C) -> maps:keys(C) end,
+                                           fun(K, C) -> maps:get(K, C, undefined) end,
+                                           []),
+    ?assertEqual(Ctx0, Ctx1),
+    ok.
+
+extract_ignores_invalid_iolist(_Config) ->
+    %% Lists that aren't valid iolists (non-byte integers, improper lists)
+    %% are attacker-controlled content; treat them as missing rather than
+    %% crashing in `iolist_size/1'.
+    [begin
+         Ctx = extract(Header),
+         ?assertEqual(#{}, otel_baggage:get_all(Ctx))
+     end || Header <- [[300], [1 | 2]]],
+    ok.
+
+extract_ignores_undecodable_binary(_Config) ->
+    %% A binary whose bytes aren't valid UTF-8 makes `string:lexemes/2'
+    %% raise (e.g., `badarg'); treat it as missing rather than crashing in
+    %% `decode_pairs/3'.
+    Ctx = extract(<<255>>),
+    ?assertEqual(#{}, otel_baggage:get_all(Ctx)),
+    ok.
+
+extract_rejects_non_string_value(_Config) ->
+    %% A carrier value that isn't a binary or list violates the TextMap
+    %% carrier contract; reject it loudly instead of silently ignoring it.
+    [?assertError({invalid_baggage_header, _}, extract(Value))
+     || Value <- [42, foo, #{}]],
+    ok.
+
+%% helpers
+
+extract(Header) ->
+    Carrier = #{?BAGGAGE_HEADER => Header},
+    Ctx = otel_ctx:new(),
+    otel_propagator_baggage:extract(Ctx, Carrier,
+                                    fun(C) -> maps:keys(C) end,
+                                    fun(K, C) -> maps:get(K, C, undefined) end,
+                                    []).
+
+build_header(N) ->
+    Pairs = [io_lib:format("k~B=v~B", [I, I]) || I <- lists:seq(1, N)],
+    iolist_to_binary(lists:join(<<",">>, Pairs)).
+
+build_short_header(N) ->
+    Pairs = [["k", integer_to_list(I), "=v"] || I <- lists:seq(1, N)],
+    iolist_to_binary(lists:join(<<",">>, Pairs)).


### PR DESCRIPTION
otel_propagator_baggage:extract/5 previously walked the inbound `baggage` header via string:lexemes/2 and lists:foldl/3 with no byte or entry-count cap, and crashed on malformed pairs through `[Key, Value] = string:split(Pair, "=")`.

Add ?MAX_BAGGAGE_BYTES (8192) and ?MAX_BAGGAGE_ENTRIES (180) limits recommended by the W3C Baggage specification, dropping oversized headers and stopping the decode loop after the entry cap. Malformed pairs are now skipped instead of crashing. This brings the Erlang implementation in line with the other OpenTelemetry SDKs and addresses GHSA-64w2-whjg-q7q7.

Adds a CT suite covering simple extract, byte cap, entry cap, within-cap, malformed-pair skipping, and missing header.

Backports open-telemetry/opentelemetry-erlang#993.